### PR TITLE
Add task management API endpoints with filtering and search

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -550,39 +550,59 @@ paths:
     get:
       tags:
         - Todos
-      summary: List todos
+      summary: List todos (get_tasks)
+      description: Retrieve tasks with filtering options
       operationId: listTodos
       parameters:
         - in: query
           name: project_id
           schema:
             type: integer
+          description: Filter by project ID
         - in: query
           name: status
           schema:
             type: string
-            enum: [pending, in_progress, completed, cancelled]
+            enum: [pending, in_progress, completed, cancelled, overdue, all]
+          description: Filter by status. Use "overdue" for pending tasks past due date, "all" for no status filter.
         - in: query
-          name: due_date
+          name: start_date
           schema:
             type: string
             format: date
+          description: Filter tasks with due_date on or after this date (ISO format)
+        - in: query
+          name: end_date
+          schema:
+            type: string
+            format: date
+          description: Filter tasks with due_date on or before this date (ISO format)
+        - in: query
+          name: category
+          schema:
+            type: string
+          description: Filter by category name (project name)
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+          description: Maximum number of tasks to return
       responses:
         '200':
           description: List of todos
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Todo'
+                $ref: '#/components/schemas/TaskListResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
 
     post:
       tags:
         - Todos
-      summary: Create todo
+      summary: Create todo (create_task)
+      description: Create a new task
       operationId: createTodo
       requestBody:
         required: true
@@ -595,32 +615,38 @@ paths:
               properties:
                 title:
                   type: string
+                  description: Task title
                 description:
                   type: string
+                  description: Task details
                 project_id:
                   type: integer
+                  description: Project ID (alternative to category)
+                category:
+                  type: string
+                  description: Task category name (maps to project)
                 priority:
                   type: string
                   enum: [low, medium, high, urgent]
+                  description: Task priority
                 due_date:
                   type: string
-                  format: date-time
+                  format: date
+                  description: Due date in ISO format
                 estimated_hours:
                   type: number
                 tags:
                   type: array
                   items:
                     type: string
+                  description: Task tags
       responses:
         '201':
           description: Todo created
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: integer
+                $ref: '#/components/schemas/TaskCreateResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -700,7 +726,8 @@ paths:
     put:
       tags:
         - Todos
-      summary: Update todo
+      summary: Update todo (update_task)
+      description: Update an existing task
       operationId: updateTodo
       parameters:
         - $ref: '#/components/parameters/TodoId'
@@ -713,17 +740,25 @@ paths:
               properties:
                 title:
                   type: string
+                  description: New title
                 description:
                   type: string
+                  description: New description
                 status:
                   type: string
                   enum: [pending, in_progress, completed, cancelled]
+                  description: New status
+                category:
+                  type: string
+                  description: New category name (maps to project)
                 priority:
                   type: string
                   enum: [low, medium, high, urgent]
+                  description: New priority
                 due_date:
                   type: string
-                  format: date-time
+                  format: date
+                  description: New due date (for rescheduling)
                 estimated_hours:
                   type: number
                 actual_hours:
@@ -732,20 +767,20 @@ paths:
                   type: array
                   items:
                     type: string
+                  description: New tags
       responses:
         '200':
           description: Todo updated
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
+                $ref: '#/components/schemas/TaskUpdateResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
     delete:
       tags:
@@ -801,6 +836,54 @@ paths:
                 properties:
                   success:
                     type: boolean
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /categories:
+    get:
+      tags:
+        - Categories
+      summary: List categories (get_categories)
+      description: List all available task categories with task counts
+      operationId: listCategories
+      responses:
+        '200':
+          description: List of categories with task counts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /tasks/search:
+    get:
+      tags:
+        - Todos
+      summary: Search tasks (search_tasks)
+      description: Search tasks by keyword using full-text search
+      operationId: searchTasks
+      parameters:
+        - in: query
+          name: query
+          required: true
+          schema:
+            type: string
+          description: Search query string
+        - in: query
+          name: category
+          schema:
+            type: string
+          description: Filter results by category name
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskSearchResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -905,6 +988,117 @@ components:
           type: string
           format: date-time
 
+    Task:
+      type: object
+      description: Task object returned by API endpoints
+      properties:
+        id:
+          type: string
+          description: Task ID in format "task_{id}"
+          example: "task_123"
+        title:
+          type: string
+          description: Task title
+        description:
+          type: string
+          description: Task details
+        due_date:
+          type: string
+          format: date
+          nullable: true
+          description: Due date in ISO format
+        status:
+          type: string
+          enum: [pending, in_progress, completed, cancelled]
+        category:
+          type: string
+          nullable: true
+          description: Category name (project name)
+        priority:
+          type: string
+          enum: [low, medium, high, urgent]
+        tags:
+          type: array
+          items:
+            type: string
+        created_at:
+          type: string
+          format: date
+          nullable: true
+        updated_at:
+          type: string
+          format: date
+          nullable: true
+
+    TaskListResponse:
+      type: object
+      properties:
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Task'
+
+    TaskCreateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Task ID in format "task_{id}"
+          example: "task_456"
+        title:
+          type: string
+          description: Task title
+        status:
+          type: string
+          enum: [created]
+          description: Creation status
+
+    TaskUpdateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Task ID in format "task_{id}"
+          example: "task_123"
+        updated_fields:
+          type: array
+          items:
+            type: string
+          description: List of field names that were updated
+        status:
+          type: string
+          enum: [updated]
+          description: Update status
+
+    TaskSearchResponse:
+      type: object
+      properties:
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Task'
+        count:
+          type: integer
+          description: Number of matching tasks
+
+    Category:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Category name
+        task_count:
+          type: integer
+          description: Number of tasks in this category
+
+    CategoryListResponse:
+      type: object
+      properties:
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'
+
     OAuthClient:
       type: object
       properties:
@@ -990,3 +1184,5 @@ tags:
     description: Project management endpoints
   - name: Todos
     description: Todo task management endpoints
+  - name: Categories
+    description: Task category management endpoints

--- a/src/pages/api/categories.js
+++ b/src/pages/api/categories.js
@@ -1,0 +1,18 @@
+import { TodoDB } from '../../lib/db.js';
+import { requireAuth } from '../../lib/auth.js';
+
+export const GET = async ({ request }) => {
+  const session = await requireAuth(request);
+
+  const categories = await TodoDB.getCategoriesWithCounts(session.user_id);
+
+  const formattedCategories = categories.map((cat) => ({
+    name: cat.name,
+    task_count: parseInt(cat.task_count, 10),
+  }));
+
+  return new Response(JSON.stringify({ categories: formattedCategories }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/tasks/search.js
+++ b/src/pages/api/tasks/search.js
@@ -1,0 +1,51 @@
+import { TodoDB } from '../../../lib/db.js';
+import { requireAuth } from '../../../lib/auth.js';
+
+export const GET = async ({ url, request }) => {
+  const session = await requireAuth(request);
+  const searchParams = new URL(url).searchParams;
+  const query = searchParams.get('query');
+  const category = searchParams.get('category');
+
+  if (!query) {
+    return new Response(
+      JSON.stringify({ error: 'Query parameter is required' }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+
+  const todos = await TodoDB.searchTodos(session.user_id, query, category);
+
+  const formattedTasks = todos.map((todo) => ({
+    id: `task_${todo.id}`,
+    title: todo.title,
+    description: todo.description || '',
+    due_date: todo.due_date
+      ? new Date(todo.due_date).toISOString().split('T')[0]
+      : null,
+    status: todo.status,
+    category: todo.project_name || null,
+    priority: todo.priority,
+    tags: typeof todo.tags === 'string' ? JSON.parse(todo.tags) : todo.tags || [],
+    created_at: todo.created_at
+      ? new Date(todo.created_at).toISOString().split('T')[0]
+      : null,
+    updated_at: todo.updated_at
+      ? new Date(todo.updated_at).toISOString().split('T')[0]
+      : null,
+  }));
+
+  return new Response(
+    JSON.stringify({
+      tasks: formattedTasks,
+      count: formattedTasks.length,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+};

--- a/src/pages/api/todos.js
+++ b/src/pages/api/todos.js
@@ -6,15 +6,42 @@ export const GET = async ({ url, request }) => {
   const searchParams = new URL(url).searchParams;
   const projectId = searchParams.get('project_id');
   const status = searchParams.get('status');
-  const dueDate = searchParams.get('due_date');
+  const startDate = searchParams.get('start_date');
+  const endDate = searchParams.get('end_date');
+  const category = searchParams.get('category');
+  const limitParam = searchParams.get('limit');
+  const limit = limitParam ? parseInt(limitParam, 10) : null;
 
-  const todos = await TodoDB.getTodos(
-    session.user_id,
+  const todos = await TodoDB.getTodosFiltered(session.user_id, {
     projectId,
     status,
-    dueDate
-  );
-  return new Response(JSON.stringify(todos), {
+    startDate,
+    endDate,
+    category,
+    limit,
+  });
+
+  // Format response to match expected API structure
+  const formattedTasks = todos.map((todo) => ({
+    id: `task_${todo.id}`,
+    title: todo.title,
+    description: todo.description || '',
+    due_date: todo.due_date
+      ? new Date(todo.due_date).toISOString().split('T')[0]
+      : null,
+    status: todo.status,
+    category: todo.project_name || null,
+    priority: todo.priority,
+    tags: typeof todo.tags === 'string' ? JSON.parse(todo.tags) : todo.tags || [],
+    created_at: todo.created_at
+      ? new Date(todo.created_at).toISOString().split('T')[0]
+      : null,
+    updated_at: todo.updated_at
+      ? new Date(todo.updated_at).toISOString().split('T')[0]
+      : null,
+  }));
+
+  return new Response(JSON.stringify({ tasks: formattedTasks }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });
@@ -23,11 +50,32 @@ export const GET = async ({ url, request }) => {
 export const POST = async ({ request }) => {
   const session = await requireAuth(request);
   const body = await request.json();
-  const result = await TodoDB.createTodo(session.user_id, body);
-  return new Response(JSON.stringify({ id: result.lastInsertRowid }), {
-    status: 201,
-    headers: { 'Content-Type': 'application/json' },
-  });
+
+  // Map category to project_id if provided
+  let todoData = { ...body };
+  if (body.category && !body.project_id) {
+    // Look up project by name to get project_id
+    const projects = await TodoDB.getProjects(session.user_id);
+    const project = projects.find(
+      (p) => p.name.toLowerCase() === body.category.toLowerCase()
+    );
+    if (project) {
+      todoData.project_id = project.id;
+    }
+  }
+
+  const result = await TodoDB.createTodo(session.user_id, todoData);
+  return new Response(
+    JSON.stringify({
+      id: `task_${result.id}`,
+      title: body.title,
+      status: 'created',
+    }),
+    {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
 };
 
 export const PUT = async ({ request }) => {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -18,6 +18,8 @@ describe('API Route Authentication', () => {
       { path: '/api/todos', name: 'Todos API' },
       { path: '/api/todos/456', name: 'Single todo API' },
       { path: '/api/todos/456/complete', name: 'Complete todo API' },
+      { path: '/api/categories', name: 'Categories API' },
+      { path: '/api/tasks/search', name: 'Tasks search API' },
       { path: '/api/auth/logout', name: 'Logout API' },
       // { path: '/api/auth/register', name: 'Register API' },
       { path: '/api/oauth/clients', name: 'OAuth clients API' },

--- a/tests/todos-api.test.js
+++ b/tests/todos-api.test.js
@@ -1,0 +1,385 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the database and auth modules
+vi.mock('../src/lib/db.js', () => ({
+  TodoDB: {
+    getTodosFiltered: vi.fn(),
+    createTodo: vi.fn(),
+    updateTodo: vi.fn(),
+    getTodoById: vi.fn(),
+    getProjects: vi.fn(),
+    getCategoriesWithCounts: vi.fn(),
+    searchTodos: vi.fn(),
+  },
+}));
+
+vi.mock('../src/lib/auth.js', () => ({
+  requireAuth: vi.fn(),
+}));
+
+import { TodoDB } from '../src/lib/db.js';
+import { requireAuth } from '../src/lib/auth.js';
+import { GET as getTodos, POST as createTodo } from '../src/pages/api/todos.js';
+import { PUT as updateTodo } from '../src/pages/api/todos/[id].js';
+import { GET as getCategories } from '../src/pages/api/categories.js';
+import { GET as searchTasks } from '../src/pages/api/tasks/search.js';
+
+const mockSession = { user_id: 1, username: 'testuser' };
+
+const createMockRequest = (url, options = {}) => {
+  return new Request(url, options);
+};
+
+describe('GET /api/todos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuth.mockResolvedValue(mockSession);
+  });
+
+  it('should return tasks with proper format', async () => {
+    const mockTodos = [
+      {
+        id: 1,
+        title: 'Test Task',
+        description: 'Test description',
+        due_date: new Date('2025-12-20'),
+        status: 'pending',
+        project_name: 'work',
+        priority: 'high',
+        tags: ['urgent'],
+        created_at: new Date('2025-12-01'),
+        updated_at: new Date('2025-12-10'),
+      },
+    ];
+
+    TodoDB.getTodosFiltered.mockResolvedValue(mockTodos);
+
+    const request = createMockRequest('http://localhost:3000/api/todos');
+    const response = await getTodos({ url: request.url, request });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data).toHaveProperty('tasks');
+    expect(data.tasks).toHaveLength(1);
+    expect(data.tasks[0]).toEqual({
+      id: 'task_1',
+      title: 'Test Task',
+      description: 'Test description',
+      due_date: '2025-12-20',
+      status: 'pending',
+      category: 'work',
+      priority: 'high',
+      tags: ['urgent'],
+      created_at: '2025-12-01',
+      updated_at: '2025-12-10',
+    });
+  });
+
+  it('should pass filter parameters to database', async () => {
+    TodoDB.getTodosFiltered.mockResolvedValue([]);
+
+    const request = createMockRequest(
+      'http://localhost:3000/api/todos?status=pending&start_date=2025-12-01&end_date=2025-12-31&category=work&limit=10'
+    );
+    await getTodos({ url: request.url, request });
+
+    expect(TodoDB.getTodosFiltered).toHaveBeenCalledWith(1, {
+      projectId: null,
+      status: 'pending',
+      startDate: '2025-12-01',
+      endDate: '2025-12-31',
+      category: 'work',
+      limit: 10,
+    });
+  });
+
+  it('should handle empty results', async () => {
+    TodoDB.getTodosFiltered.mockResolvedValue([]);
+
+    const request = createMockRequest('http://localhost:3000/api/todos');
+    const response = await getTodos({ url: request.url, request });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.tasks).toEqual([]);
+  });
+
+  it('should parse JSON tags when stored as string', async () => {
+    const mockTodos = [
+      {
+        id: 1,
+        title: 'Test',
+        tags: '["tag1", "tag2"]',
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+    ];
+
+    TodoDB.getTodosFiltered.mockResolvedValue(mockTodos);
+
+    const request = createMockRequest('http://localhost:3000/api/todos');
+    const response = await getTodos({ url: request.url, request });
+    const data = await response.json();
+
+    expect(data.tasks[0].tags).toEqual(['tag1', 'tag2']);
+  });
+});
+
+describe('POST /api/todos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuth.mockResolvedValue(mockSession);
+  });
+
+  it('should create a task and return proper format', async () => {
+    TodoDB.createTodo.mockResolvedValue({ id: 123 });
+
+    const request = createMockRequest('http://localhost:3000/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'New Task',
+        description: 'Task description',
+        priority: 'high',
+      }),
+    });
+
+    const response = await createTodo({ request });
+
+    expect(response.status).toBe(201);
+    const data = await response.json();
+
+    expect(data).toEqual({
+      id: 'task_123',
+      title: 'New Task',
+      status: 'created',
+    });
+  });
+
+  it('should map category to project_id when provided', async () => {
+    const mockProjects = [
+      { id: 5, name: 'Work' },
+      { id: 6, name: 'Personal' },
+    ];
+
+    TodoDB.getProjects.mockResolvedValue(mockProjects);
+    TodoDB.createTodo.mockResolvedValue({ id: 456 });
+
+    const request = createMockRequest('http://localhost:3000/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Categorized Task',
+        category: 'work',
+      }),
+    });
+
+    await createTodo({ request });
+
+    expect(TodoDB.createTodo).toHaveBeenCalledWith(1, {
+      title: 'Categorized Task',
+      category: 'work',
+      project_id: 5,
+    });
+  });
+});
+
+describe('PUT /api/todos/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuth.mockResolvedValue(mockSession);
+  });
+
+  it('should update a task and return proper format', async () => {
+    TodoDB.getTodoById.mockResolvedValue({ id: 123, title: 'Old Title' });
+    TodoDB.updateTodo.mockResolvedValue({ id: 123 });
+
+    const request = createMockRequest('http://localhost:3000/api/todos/123', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Updated Title',
+        priority: 'urgent',
+      }),
+    });
+
+    const response = await updateTodo({ params: { id: '123' }, request });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data).toEqual({
+      id: 'task_123',
+      updated_fields: ['title', 'priority'],
+      status: 'updated',
+    });
+  });
+
+  it('should return 404 for non-existent task', async () => {
+    TodoDB.getTodoById.mockResolvedValue(null);
+
+    const request = createMockRequest('http://localhost:3000/api/todos/999', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Test' }),
+    });
+
+    const response = await updateTodo({ params: { id: '999' }, request });
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error).toBe('Todo not found');
+  });
+
+  it('should return 400 for invalid todo ID', async () => {
+    const request = createMockRequest('http://localhost:3000/api/todos/invalid', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Test' }),
+    });
+
+    const response = await updateTodo({ params: { id: 'invalid' }, request });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should map category to project_id when updating', async () => {
+    const mockProjects = [{ id: 10, name: 'Research' }];
+
+    TodoDB.getTodoById.mockResolvedValue({ id: 123 });
+    TodoDB.getProjects.mockResolvedValue(mockProjects);
+    TodoDB.updateTodo.mockResolvedValue({ id: 123 });
+
+    const request = createMockRequest('http://localhost:3000/api/todos/123', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category: 'research' }),
+    });
+
+    await updateTodo({ params: { id: '123' }, request });
+
+    expect(TodoDB.updateTodo).toHaveBeenCalledWith(123, 1, { project_id: 10 });
+  });
+});
+
+describe('GET /api/categories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuth.mockResolvedValue(mockSession);
+  });
+
+  it('should return categories with task counts', async () => {
+    const mockCategories = [
+      { name: 'work', task_count: '15' },
+      { name: 'personal', task_count: '8' },
+      { name: 'research', task_count: '5' },
+    ];
+
+    TodoDB.getCategoriesWithCounts.mockResolvedValue(mockCategories);
+
+    const request = createMockRequest('http://localhost:3000/api/categories');
+    const response = await getCategories({ request });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data).toEqual({
+      categories: [
+        { name: 'work', task_count: 15 },
+        { name: 'personal', task_count: 8 },
+        { name: 'research', task_count: 5 },
+      ],
+    });
+  });
+
+  it('should return empty array when no categories exist', async () => {
+    TodoDB.getCategoriesWithCounts.mockResolvedValue([]);
+
+    const request = createMockRequest('http://localhost:3000/api/categories');
+    const response = await getCategories({ request });
+
+    const data = await response.json();
+    expect(data.categories).toEqual([]);
+  });
+});
+
+describe('GET /api/tasks/search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuth.mockResolvedValue(mockSession);
+  });
+
+  it('should search tasks and return results with count', async () => {
+    const mockResults = [
+      {
+        id: 1,
+        title: 'Meeting notes',
+        description: 'Notes from team meeting',
+        status: 'completed',
+        project_name: 'work',
+        priority: 'medium',
+        tags: [],
+        created_at: new Date('2025-12-01'),
+        updated_at: new Date('2025-12-10'),
+      },
+      {
+        id: 2,
+        title: 'Research meeting agenda',
+        status: 'pending',
+        project_name: 'research',
+        priority: 'high',
+        tags: ['urgent'],
+        created_at: new Date('2025-12-05'),
+        updated_at: new Date('2025-12-05'),
+      },
+    ];
+
+    TodoDB.searchTodos.mockResolvedValue(mockResults);
+
+    const request = createMockRequest(
+      'http://localhost:3000/api/tasks/search?query=meeting'
+    );
+    const response = await searchTasks({ url: request.url, request });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.tasks).toHaveLength(2);
+    expect(data.count).toBe(2);
+    expect(TodoDB.searchTodos).toHaveBeenCalledWith(1, 'meeting', null);
+  });
+
+  it('should filter search by category', async () => {
+    TodoDB.searchTodos.mockResolvedValue([]);
+
+    const request = createMockRequest(
+      'http://localhost:3000/api/tasks/search?query=meeting&category=work'
+    );
+    await searchTasks({ url: request.url, request });
+
+    expect(TodoDB.searchTodos).toHaveBeenCalledWith(1, 'meeting', 'work');
+  });
+
+  it('should return 400 when query is missing', async () => {
+    const request = createMockRequest('http://localhost:3000/api/tasks/search');
+    const response = await searchTasks({ url: request.url, request });
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe('Query parameter is required');
+  });
+
+  it('should return empty results for no matches', async () => {
+    TodoDB.searchTodos.mockResolvedValue([]);
+
+    const request = createMockRequest(
+      'http://localhost:3000/api/tasks/search?query=nonexistent'
+    );
+    const response = await searchTasks({ url: request.url, request });
+
+    const data = await response.json();
+    expect(data.tasks).toEqual([]);
+    expect(data.count).toBe(0);
+  });
+});


### PR DESCRIPTION
- Add GET /api/todos filtering: status, start_date, end_date, category, limit
- Update POST /api/todos to accept category and return {id, title, status}
- Update PUT /api/todos/[id] to return {id, updated_fields, status}
- Add GET /api/categories endpoint with task counts
- Add GET /api/tasks/search endpoint with full-text search
- Add comprehensive unit tests for all new API functionality
- Update OpenAPI spec with new endpoints and response schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)