### PR TITLE
Add migration for MCP access tokens table

### DIFF
--- a/src/migrations/20251223062149_mcp_access_tokens.down.sql
+++ b/src/migrations/20251223062149_mcp_access_tokens.down.sql
@@ -1,0 +1,6 @@
+-- Migration: mcp_access_tokens (rollback)
+-- Created: 2025-12-23
+
+DROP INDEX IF EXISTS idx_mcp_access_tokens_expires_at;
+DROP INDEX IF EXISTS idx_mcp_access_tokens_token;
+DROP TABLE IF EXISTS mcp_access_tokens;

--- a/src/migrations/20251223062149_mcp_access_tokens.up.sql
+++ b/src/migrations/20251223062149_mcp_access_tokens.up.sql
@@ -1,0 +1,20 @@
+-- Migration: mcp_access_tokens
+-- Created: 2025-12-23
+-- Add table for MCP (Model Context Protocol) access tokens
+-- These tokens are issued by the MCP auth server after TaskManager OAuth authentication
+
+CREATE TABLE IF NOT EXISTS mcp_access_tokens (
+  id SERIAL PRIMARY KEY,
+  token VARCHAR(255) UNIQUE NOT NULL,
+  client_id VARCHAR(255) NOT NULL,
+  scopes TEXT NOT NULL,
+  resource VARCHAR(500),  -- RFC 8707 resource binding (audience)
+  expires_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create index for fast token lookups during introspection
+CREATE INDEX IF NOT EXISTS idx_mcp_access_tokens_token ON mcp_access_tokens(token);
+
+-- Create index for cleanup of expired tokens
+CREATE INDEX IF NOT EXISTS idx_mcp_access_tokens_expires_at ON mcp_access_tokens(expires_at);


### PR DESCRIPTION
Add database table to store MCP (Model Context Protocol) access tokens, enabling persistent token storage across auth server restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)