### PR TITLE
Fix task date timezone issue causing off-by-one day display

### DIFF
--- a/src/components/DragDropCalendar.astro
+++ b/src/components/DragDropCalendar.astro
@@ -84,7 +84,11 @@
 
         const dayDiv = document.createElement('div');
         dayDiv.className = 'calendar-day';
-        dayDiv.dataset.date = date.toISOString().split('T')[0];
+        // Use local date methods to avoid timezone shifts
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        dayDiv.dataset.date = `${year}-${month}-${day}`;
 
         // Check if today
         const today = new Date();

--- a/src/lib/apiResponse.js
+++ b/src/lib/apiResponse.js
@@ -363,12 +363,29 @@ export const oauthErrors = {
 
 /**
  * Format a date to ISO date string (YYYY-MM-DD) or null
+ * Handles dates without timezone conversion to avoid off-by-one errors
  * @param {Date|string|null} date - Date to format
  * @returns {string|null}
  */
 export function formatDateString(date) {
   if (!date) return null;
-  return new Date(date).toISOString().split('T')[0];
+
+  // If already a YYYY-MM-DD string, return as-is
+  if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return date;
+  }
+
+  // If it's a string with time component, extract just the date part
+  if (typeof date === 'string' && date.includes('T')) {
+    return date.split('T')[0];
+  }
+
+  // For Date objects, use local date methods to avoid timezone shifts
+  const d = new Date(date);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 /**

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,6 +49,15 @@ const user = Astro.locals.user;
       .replace(/'/g, '&#039;');
   }
 
+  // Format a YYYY-MM-DD date string for display without timezone conversion
+  function formatDateForDisplay(dateStr) {
+    if (!dateStr) return '';
+    // Parse the date string as local date (not UTC)
+    const [year, month, day] = dateStr.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
+    return date.toLocaleDateString();
+  }
+
   async function loadTodos() {
     try {
       const apiUrl = `/api/todos?status=pending`;
@@ -115,7 +124,7 @@ const user = Astro.locals.user;
                   <div class="font-medium">${escapeHtml(todo.title)}</div>
                   <div class="text-sm text-gray-600">${escapeHtml(todo.description)}</div>
                   <div class="text-xs text-gray-500 mt-1">
-                    Priority: ${escapeHtml(todo.priority)}${todo.due_date ? ` | Due: ${new Date(todo.due_date).toLocaleDateString()}` : ''}
+                    Priority: ${escapeHtml(todo.priority)}${todo.due_date ? ` | Due: ${formatDateForDisplay(todo.due_date)}` : ''}
                   </div>
                 </div>
                 <div class="flex gap-3 ml-4">


### PR DESCRIPTION
The bug occurred because JavaScript's `new Date("YYYY-MM-DD")` interprets
date-only strings as UTC midnight. When displayed in a timezone west of
UTC, dates would appear one day earlier than expected.

Changes:
- formatDateString(): Now preserves YYYY-MM-DD strings as-is and uses
  local date methods for Date objects instead of toISOString()
- DragDropCalendar: Calendar day generation now uses local date methods
  instead of toISOString().split('T')[0]
- index.astro: Added formatDateForDisplay() helper that parses date
  strings as local dates to avoid timezone conversion