### PR TITLE
Add deleted tasks view with search and restore functionality

### DIFF
--- a/services/mcp-auth/Dockerfile
+++ b/services/mcp-auth/Dockerfile
@@ -19,8 +19,9 @@ COPY packages/taskmanager-sdk /packages/taskmanager-sdk
 # Copy dependency files
 COPY services/mcp-auth/pyproject.toml ./
 
-# Install dependencies using uv
-RUN uv sync --no-dev
+# Update pyproject.toml to use absolute path for Docker build, then install dependencies
+RUN sed -i 's|path = "../../packages/taskmanager-sdk"|path = "/packages/taskmanager-sdk"|' pyproject.toml \
+    && uv sync --no-dev
 
 # Copy application code
 COPY services/mcp-auth/mcp_auth ./mcp_auth

--- a/services/mcp-resource/Dockerfile
+++ b/services/mcp-resource/Dockerfile
@@ -19,8 +19,9 @@ COPY packages/taskmanager-sdk /packages/taskmanager-sdk
 # Copy dependency files
 COPY services/mcp-resource/pyproject.toml ./
 
-# Install dependencies using uv
-RUN uv sync --no-dev
+# Update pyproject.toml to use absolute path for Docker build, then install dependencies
+RUN sed -i 's|path = "../../packages/taskmanager-sdk"|path = "/packages/taskmanager-sdk"|' pyproject.toml \
+    && uv sync --no-dev
 
 # Copy application code
 COPY services/mcp-resource/mcp_resource ./mcp_resource

--- a/services/web-app/openapi.yaml
+++ b/services/web-app/openapi.yaml
@@ -65,6 +65,8 @@ tags:
     description: Authentication endpoints
   - name: Todos
     description: Task management
+  - name: Trash
+    description: Deleted task management
   - name: Projects
     description: Project management
   - name: OAuth
@@ -490,6 +492,97 @@ paths:
       responses:
         '200':
           description: Search results
+
+  /api/trash:
+    get:
+      tags: [Trash]
+      summary: List deleted todos
+      description: Returns all soft-deleted todos for the authenticated user. Supports full-text search via query parameter.
+      security:
+        - sessionCookie: []
+        - bearerAuth: []
+      parameters:
+        - name: query
+          in: query
+          description: Search query for filtering deleted todos by title/description
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of deleted todos
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tasks:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: '#/components/schemas/Todo'
+                        - type: object
+                          properties:
+                            deleted_at:
+                              type: string
+                              format: date
+                              description: Date when the todo was deleted
+                  count:
+                    type: integer
+                    description: Number of deleted todos returned
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /api/trash/{id}/restore:
+    post:
+      tags: [Trash]
+      summary: Restore a deleted todo
+      description: Restores a soft-deleted todo back to the active todos list.
+      security:
+        - sessionCookie: []
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the deleted todo to restore
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Todo restored successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  restored:
+                    type: boolean
+                    example: true
+                  id:
+                    type: integer
+                    description: ID of the restored todo
+        '400':
+          description: Invalid todo ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Deleted todo not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /api/projects:
     get:

--- a/services/web-app/src/components/Navigation.astro
+++ b/services/web-app/src/components/Navigation.astro
@@ -31,6 +31,12 @@ const { user } = Astro.props;
               >
                 OAuth Clients
               </a>
+              <a
+                href="/trash"
+                class={`nav-link ${currentPath === '/trash' ? 'active' : ''}`}
+              >
+                Trash
+              </a>
             </div>
           )
         }

--- a/services/web-app/src/migrations/20260113000000_add_todo_deleted_at.down.sql
+++ b/services/web-app/src/migrations/20260113000000_add_todo_deleted_at.down.sql
@@ -1,0 +1,4 @@
+-- Migration: add_todo_deleted_at (rollback)
+
+DROP INDEX IF EXISTS idx_todos_deleted_at;
+ALTER TABLE todos DROP COLUMN IF EXISTS deleted_at;

--- a/services/web-app/src/migrations/20260113000000_add_todo_deleted_at.up.sql
+++ b/services/web-app/src/migrations/20260113000000_add_todo_deleted_at.up.sql
@@ -1,0 +1,8 @@
+-- Migration: add_todo_deleted_at
+-- Add soft delete support for todos
+
+-- Add deleted_at column (NULL = not deleted, timestamp = when deleted)
+ALTER TABLE todos ADD COLUMN deleted_at TIMESTAMP DEFAULT NULL;
+
+-- Index for efficiently querying non-deleted and deleted todos
+CREATE INDEX idx_todos_deleted_at ON todos(deleted_at);

--- a/services/web-app/src/pages/api/trash.js
+++ b/services/web-app/src/pages/api/trash.js
@@ -1,0 +1,44 @@
+import { TodoDB } from '../../lib/db.js';
+import { requireAuth } from '../../lib/auth.js';
+import { errors } from '../../lib/errors.js';
+import { successResponse, formatDateString } from '../../lib/apiResponse.js';
+
+export const GET = async ({ url, request }) => {
+  try {
+    const session = await requireAuth(request);
+    const searchParams = new URL(url).searchParams;
+    const query = searchParams.get('query');
+
+    let todos;
+    if (query && query.trim()) {
+      todos = await TodoDB.searchDeletedTodos(session.user_id, query.trim());
+    } else {
+      todos = await TodoDB.getDeletedTodos(session.user_id);
+    }
+
+    const formattedTasks = todos.map((todo) => ({
+      id: todo.id,
+      title: todo.title,
+      description: todo.description || '',
+      due_date: formatDateString(todo.due_date),
+      status: todo.status,
+      project_name: todo.project_name || null,
+      project_color: todo.project_color || null,
+      priority: todo.priority,
+      tags:
+        typeof todo.tags === 'string' ? JSON.parse(todo.tags) : todo.tags || [],
+      deleted_at: formatDateString(todo.deleted_at),
+      created_at: formatDateString(todo.created_at),
+    }));
+
+    return successResponse({
+      tasks: formattedTasks,
+      count: formattedTasks.length,
+    });
+  } catch (error) {
+    if (error.message === 'Authentication required') {
+      return errors.authRequired().toResponse();
+    }
+    return errors.internal(error.message).toResponse();
+  }
+};

--- a/services/web-app/src/pages/api/trash/[id]/restore.js
+++ b/services/web-app/src/pages/api/trash/[id]/restore.js
@@ -1,0 +1,34 @@
+import { TodoDB } from '../../../../lib/db.js';
+import { requireAuth } from '../../../../lib/auth.js';
+import { errors } from '../../../../lib/errors.js';
+import { validateId } from '../../../../lib/validators.js';
+import { successResponse } from '../../../../lib/apiResponse.js';
+
+export const POST = async ({ params, request }) => {
+  try {
+    const session = await requireAuth(request);
+
+    const idResult = validateId(params.id, 'Todo ID');
+    if (!idResult.valid) {
+      return idResult.error.toResponse();
+    }
+
+    // Check if deleted todo exists
+    const todo = await TodoDB.getDeletedTodoById(
+      idResult.value,
+      session.user_id
+    );
+    if (!todo) {
+      return errors.notFound('Deleted task').toResponse();
+    }
+
+    const restored = await TodoDB.restoreTodo(idResult.value, session.user_id);
+
+    return successResponse({ restored: true, id: restored.id });
+  } catch (error) {
+    if (error.message === 'Authentication required') {
+      return errors.authRequired().toResponse();
+    }
+    return errors.internal(error.message).toResponse();
+  }
+};

--- a/services/web-app/src/pages/trash.astro
+++ b/services/web-app/src/pages/trash.astro
@@ -1,0 +1,200 @@
+---
+// src/pages/trash.astro - View and restore deleted tasks
+import Layout from '../layouts/Layout.astro';
+import { checkAuthAsync } from '../lib/auth.js';
+
+const auth = await checkAuthAsync(Astro.request);
+if (auth.redirect) return auth.redirect;
+const user = auth.user;
+---
+
+<Layout title="Deleted Tasks" user={user}>
+  <main class="container py-8">
+    <h1 class="text-3xl font-bold text-gray-900 mb-8">Deleted Tasks</h1>
+
+    <!-- Search Bar -->
+    <div class="max-w-4xl mx-auto mb-6">
+      <div class="flex gap-4">
+        <input
+          type="text"
+          id="search-input"
+          placeholder="Search deleted tasks..."
+          class="form-input flex-1"
+        />
+        <button id="search-btn" class="btn btn-primary">Search</button>
+        <button id="clear-btn" class="btn btn-secondary hidden">Clear</button>
+      </div>
+    </div>
+
+    <!-- Deleted Tasks List -->
+    <div class="max-w-4xl mx-auto">
+      <div id="trash-list" class="space-y-4">
+        <!-- Deleted tasks will be loaded here -->
+      </div>
+      <div id="empty-state" class="hidden text-center py-8 text-gray-500">
+        <p>No deleted tasks found.</p>
+      </div>
+    </div>
+  </main>
+</Layout>
+
+<script>
+  // Escape HTML to prevent XSS
+  function escapeHtml(unsafe) {
+    if (unsafe == null) return '';
+    return String(unsafe)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function formatDateForDisplay(dateStr) {
+    if (!dateStr) return '';
+    const [year, month, day] = dateStr.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
+    return date.toLocaleDateString();
+  }
+
+  function getPriorityBadgeClass(priority) {
+    switch (priority) {
+      case 'urgent':
+        return 'bg-red-100 text-red-800';
+      case 'high':
+        return 'bg-orange-100 text-orange-800';
+      case 'medium':
+        return 'bg-yellow-100 text-yellow-800';
+      case 'low':
+        return 'bg-green-100 text-green-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  }
+
+  async function loadDeletedTasks(query = '') {
+    try {
+      const url = query
+        ? `/api/trash?query=${encodeURIComponent(query)}`
+        : '/api/trash';
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          window.location.href = '/login';
+          return;
+        }
+        throw new Error('Failed to load deleted tasks');
+      }
+
+      const data = await response.json();
+      const tasks = data.tasks || [];
+      const container = document.getElementById('trash-list');
+      const emptyState = document.getElementById('empty-state');
+
+      container.innerHTML = '';
+
+      if (tasks.length === 0) {
+        container.classList.add('hidden');
+        emptyState.classList.remove('hidden');
+        return;
+      }
+
+      container.classList.remove('hidden');
+      emptyState.classList.add('hidden');
+
+      tasks.forEach((task) => {
+        const taskDiv = document.createElement('div');
+        taskDiv.className = 'card border-l-4';
+        taskDiv.style.borderLeftColor = task.project_color || '#9ca3af';
+
+        const priorityBadge = `<span class="text-xs px-2 py-1 rounded ${getPriorityBadgeClass(task.priority)}">${escapeHtml(task.priority)}</span>`;
+
+        taskDiv.innerHTML = `
+          <div class="flex items-start justify-between gap-4">
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2 mb-1">
+                <h3 class="font-semibold text-lg text-gray-800 truncate">${escapeHtml(task.title)}</h3>
+                ${priorityBadge}
+              </div>
+              <p class="text-gray-600 text-sm mt-1 line-clamp-2">${escapeHtml(task.description) || 'No description'}</p>
+              <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 mt-3">
+                ${task.project_name ? `<span>Project: ${escapeHtml(task.project_name)}</span>` : ''}
+                ${task.due_date ? `<span>Due: ${formatDateForDisplay(task.due_date)}</span>` : ''}
+                <span>Deleted: ${formatDateForDisplay(task.deleted_at)}</span>
+              </div>
+            </div>
+            <div class="flex-shrink-0">
+              <button
+                onclick="restoreTask(${parseInt(task.id, 10)})"
+                class="btn btn-primary btn-sm"
+                title="Restore task"
+              >
+                Restore
+              </button>
+            </div>
+          </div>
+        `;
+
+        container.appendChild(taskDiv);
+      });
+    } catch (error) {
+      console.error('Failed to load deleted tasks:', error);
+      document.getElementById('trash-list').innerHTML =
+        '<p class="text-red-500">Failed to load deleted tasks</p>';
+      document.getElementById('empty-state').classList.add('hidden');
+    }
+  }
+
+  window.restoreTask = async function (taskId) {
+    try {
+      const response = await fetch(`/api/trash/${taskId}/restore`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (response.ok) {
+        // Reload the list after successful restore
+        const searchInput = document.getElementById('search-input');
+        loadDeletedTasks(searchInput.value.trim());
+      } else if (response.status === 401) {
+        window.location.href = '/login';
+      } else {
+        const data = await response.json();
+        alert(data.error?.message || 'Failed to restore task');
+      }
+    } catch (error) {
+      alert('Error: ' + error.message);
+    }
+  };
+
+  // Search functionality
+  const searchInput = document.getElementById('search-input');
+  const searchBtn = document.getElementById('search-btn');
+  const clearBtn = document.getElementById('clear-btn');
+
+  searchBtn.addEventListener('click', () => {
+    const query = searchInput.value.trim();
+    if (query) {
+      loadDeletedTasks(query);
+      clearBtn.classList.remove('hidden');
+    } else {
+      loadDeletedTasks();
+    }
+  });
+
+  searchInput.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') {
+      searchBtn.click();
+    }
+  });
+
+  clearBtn.addEventListener('click', () => {
+    searchInput.value = '';
+    clearBtn.classList.add('hidden');
+    loadDeletedTasks();
+  });
+
+  // Load deleted tasks on page load
+  loadDeletedTasks();
+</script>

--- a/services/web-app/tests/pages.test.js
+++ b/services/web-app/tests/pages.test.js
@@ -15,6 +15,7 @@ describe('Page Route Authentication', () => {
     const protectedPageRoutes = [
       { path: '/', name: 'Home page' },
       { path: '/projects', name: 'Projects page' },
+      { path: '/trash', name: 'Trash page' },
     ];
 
     it.each(protectedPageRoutes)(

--- a/services/web-app/tests/trash-api.test.js
+++ b/services/web-app/tests/trash-api.test.js
@@ -1,0 +1,315 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the database and auth modules
+vi.mock('../src/lib/db.js', () => ({
+  TodoDB: {
+    getDeletedTodos: vi.fn(),
+    getDeletedTodoById: vi.fn(),
+    searchDeletedTodos: vi.fn(),
+    restoreTodo: vi.fn(),
+  },
+}));
+
+vi.mock('../src/lib/auth.js', () => ({
+  requireAuth: vi.fn(),
+}));
+
+import { TodoDB } from '../src/lib/db.js';
+import { requireAuth } from '../src/lib/auth.js';
+import { GET as getTrash } from '../src/pages/api/trash.js';
+import { POST as restoreTodo } from '../src/pages/api/trash/[id]/restore.js';
+
+const mockSession = { user_id: 1, username: 'testuser' };
+
+const createMockRequest = (url, options = {}) => {
+  return new Request(url, options);
+};
+
+describe('GET /api/trash', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuth.mockResolvedValue(mockSession);
+  });
+
+  it('should return deleted tasks with proper format', async () => {
+    const mockDeletedTodos = [
+      {
+        id: 1,
+        title: 'Deleted Task',
+        description: 'This was deleted',
+        due_date: new Date('2025-12-20'),
+        status: 'pending',
+        project_name: 'work',
+        project_color: '#3b82f6',
+        priority: 'high',
+        tags: ['important'],
+        deleted_at: new Date('2025-12-25'),
+        created_at: new Date('2025-12-01'),
+      },
+    ];
+
+    TodoDB.getDeletedTodos.mockResolvedValue(mockDeletedTodos);
+
+    const request = createMockRequest('http://localhost:3000/api/trash');
+    const response = await getTrash({ url: request.url, request });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data).toHaveProperty('tasks');
+    expect(data).toHaveProperty('count', 1);
+    expect(data.tasks).toHaveLength(1);
+    expect(data.tasks[0]).toEqual({
+      id: 1,
+      title: 'Deleted Task',
+      description: 'This was deleted',
+      due_date: '2025-12-20',
+      status: 'pending',
+      project_name: 'work',
+      project_color: '#3b82f6',
+      priority: 'high',
+      tags: ['important'],
+      deleted_at: '2025-12-25',
+      created_at: '2025-12-01',
+    });
+  });
+
+  it('should handle empty trash', async () => {
+    TodoDB.getDeletedTodos.mockResolvedValue([]);
+
+    const request = createMockRequest('http://localhost:3000/api/trash');
+    const response = await getTrash({ url: request.url, request });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.tasks).toEqual([]);
+    expect(data.count).toBe(0);
+  });
+
+  it('should search deleted tasks when query parameter is provided', async () => {
+    const mockSearchResults = [
+      {
+        id: 2,
+        title: 'Meeting notes',
+        description: 'Notes from meeting',
+        deleted_at: new Date('2025-12-24'),
+        created_at: new Date('2025-12-01'),
+      },
+    ];
+
+    TodoDB.searchDeletedTodos.mockResolvedValue(mockSearchResults);
+
+    const request = createMockRequest(
+      'http://localhost:3000/api/trash?query=meeting'
+    );
+    const response = await getTrash({ url: request.url, request });
+
+    expect(response.status).toBe(200);
+    expect(TodoDB.searchDeletedTodos).toHaveBeenCalledWith(1, 'meeting');
+    expect(TodoDB.getDeletedTodos).not.toHaveBeenCalled();
+
+    const data = await response.json();
+    expect(data.tasks).toHaveLength(1);
+    expect(data.count).toBe(1);
+  });
+
+  it('should ignore empty query parameter and return all deleted tasks', async () => {
+    TodoDB.getDeletedTodos.mockResolvedValue([]);
+
+    const request = createMockRequest('http://localhost:3000/api/trash?query=');
+    const response = await getTrash({ url: request.url, request });
+
+    expect(TodoDB.getDeletedTodos).toHaveBeenCalledWith(1);
+    expect(TodoDB.searchDeletedTodos).not.toHaveBeenCalled();
+  });
+
+  it('should ignore whitespace-only query parameter', async () => {
+    TodoDB.getDeletedTodos.mockResolvedValue([]);
+
+    const request = createMockRequest(
+      'http://localhost:3000/api/trash?query=%20%20'
+    );
+    const response = await getTrash({ url: request.url, request });
+
+    expect(TodoDB.getDeletedTodos).toHaveBeenCalledWith(1);
+    expect(TodoDB.searchDeletedTodos).not.toHaveBeenCalled();
+  });
+
+  it('should handle null project_name and project_color', async () => {
+    const mockDeletedTodos = [
+      {
+        id: 1,
+        title: 'Task without project',
+        project_name: null,
+        project_color: null,
+        deleted_at: new Date('2025-12-25'),
+        created_at: new Date('2025-12-01'),
+      },
+    ];
+
+    TodoDB.getDeletedTodos.mockResolvedValue(mockDeletedTodos);
+
+    const request = createMockRequest('http://localhost:3000/api/trash');
+    const response = await getTrash({ url: request.url, request });
+    const data = await response.json();
+
+    expect(data.tasks[0].project_name).toBeNull();
+    expect(data.tasks[0].project_color).toBeNull();
+  });
+
+  it('should parse JSON tags when stored as string', async () => {
+    const mockDeletedTodos = [
+      {
+        id: 1,
+        title: 'Test',
+        tags: '["tag1", "tag2"]',
+        deleted_at: new Date('2025-12-25'),
+        created_at: new Date('2025-12-01'),
+      },
+    ];
+
+    TodoDB.getDeletedTodos.mockResolvedValue(mockDeletedTodos);
+
+    const request = createMockRequest('http://localhost:3000/api/trash');
+    const response = await getTrash({ url: request.url, request });
+    const data = await response.json();
+
+    expect(data.tasks[0].tags).toEqual(['tag1', 'tag2']);
+  });
+
+  it('should handle missing tags gracefully', async () => {
+    const mockDeletedTodos = [
+      {
+        id: 1,
+        title: 'Test',
+        tags: null,
+        deleted_at: new Date('2025-12-25'),
+        created_at: new Date('2025-12-01'),
+      },
+    ];
+
+    TodoDB.getDeletedTodos.mockResolvedValue(mockDeletedTodos);
+
+    const request = createMockRequest('http://localhost:3000/api/trash');
+    const response = await getTrash({ url: request.url, request });
+    const data = await response.json();
+
+    expect(data.tasks[0].tags).toEqual([]);
+  });
+
+  it('should return 401 when not authenticated', async () => {
+    requireAuth.mockRejectedValue(new Error('Authentication required'));
+
+    const request = createMockRequest('http://localhost:3000/api/trash');
+    const response = await getTrash({ url: request.url, request });
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error.code).toBe('AUTH_002');
+  });
+});
+
+describe('POST /api/trash/[id]/restore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuth.mockResolvedValue(mockSession);
+  });
+
+  it('should restore a deleted task', async () => {
+    const mockDeletedTodo = {
+      id: 123,
+      title: 'Deleted Task',
+      deleted_at: new Date('2025-12-25'),
+    };
+
+    TodoDB.getDeletedTodoById.mockResolvedValue(mockDeletedTodo);
+    TodoDB.restoreTodo.mockResolvedValue({ id: 123, deleted_at: null });
+
+    const request = createMockRequest(
+      'http://localhost:3000/api/trash/123/restore',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    const response = await restoreTodo({ params: { id: '123' }, request });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data).toEqual({
+      restored: true,
+      id: 123,
+    });
+    expect(TodoDB.getDeletedTodoById).toHaveBeenCalledWith(123, 1);
+    expect(TodoDB.restoreTodo).toHaveBeenCalledWith(123, 1);
+  });
+
+  it('should return 404 when deleted task does not exist', async () => {
+    TodoDB.getDeletedTodoById.mockResolvedValue(null);
+
+    const request = createMockRequest(
+      'http://localhost:3000/api/trash/999/restore',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    const response = await restoreTodo({ params: { id: '999' }, request });
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error.message).toBe('Deleted task not found');
+    expect(TodoDB.restoreTodo).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 for invalid todo ID', async () => {
+    const request = createMockRequest(
+      'http://localhost:3000/api/trash/invalid/restore',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    const response = await restoreTodo({ params: { id: 'invalid' }, request });
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.message).toContain('Todo ID');
+  });
+
+  it('should return 400 for negative todo ID', async () => {
+    const request = createMockRequest(
+      'http://localhost:3000/api/trash/-1/restore',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    const response = await restoreTodo({ params: { id: '-1' }, request });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 401 when not authenticated', async () => {
+    requireAuth.mockRejectedValue(new Error('Authentication required'));
+
+    const request = createMockRequest(
+      'http://localhost:3000/api/trash/123/restore',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    const response = await restoreTodo({ params: { id: '123' }, request });
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error.code).toBe('AUTH_002');
+  });
+});


### PR DESCRIPTION
Features:
- Add soft delete for todos (deleted_at column) via database migration
- New /trash page to view, search, and restore deleted tasks
- API endpoints: GET /api/trash, POST /api/trash/[id]/restore
- Navigation link to Trash page
- Unit tests for trash API endpoints and page authentication

Also fixes Docker build issue for MCP services by rewriting the taskmanager-sdk path in pyproject.toml at build time.