### PR TITLE
Fix SvelteKit frontend dev environment and calendar edit functionality

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:8000
+BACKEND_URL=http://localhost:8000
 PUBLIC_APP_NAME=TaskManager

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,9 @@
+# Production environment variables for SvelteKit frontend
+
+# Backend API URL (for server-side proxy only, NOT for client-side code)
+# In Docker: use http://backend:8000
+# Otherwise set this to your backend URL
+BACKEND_URL=http://backend:8000
+
+# Application name (public variable, safe to include in build)
+PUBLIC_APP_NAME=TaskManager

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -6,6 +6,7 @@ node_modules
 .env
 .env.*
 !.env.example
+!.env.production
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 

--- a/frontend/src/lib/stores/projects.ts
+++ b/frontend/src/lib/stores/projects.ts
@@ -9,8 +9,10 @@ function createProjectStore() {
 		subscribe,
 		load: async () => {
 			try {
-				const projects = await api.get<Project[]>('/api/projects');
-				set(projects || []);
+				const response = await api.get<{ data: Project[]; meta?: { count: number } } | Project[]>('/api/projects');
+				// Handle both response formats: {"data": [...]} and [...]
+				const projectsList = Array.isArray(response) ? response : response.data;
+				set(projectsList || []);
 			} catch (error) {
 				console.error('Failed to load projects:', error);
 				throw error;

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -1,6 +1,5 @@
 import type { LayoutServerLoad } from './$types';
-
-const BACKEND_URL = 'http://backend:8000';
+import { BACKEND_URL } from '$env/static/private';
 
 export const load: LayoutServerLoad = async ({ cookies, url }) => {
 	const sessionId = cookies.get('session');

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -8,8 +8,7 @@
 
 	let currentView: 'list' | 'calendar' = 'calendar';
 	let minimizedProjects: Record<string, boolean> = {};
-	let editingTodo: Todo | null = null;
-	let showModal = false;
+	let todoModal: TodoModal;
 
 	onMount(async () => {
 		// Load todos and projects
@@ -41,8 +40,7 @@
 	}
 
 	function openEditModal(todo: Todo) {
-		editingTodo = todo;
-		showModal = true;
+		todoModal.openEdit(todo);
 	}
 
 	async function handleCompleteTodo(todoId: number) {
@@ -101,7 +99,7 @@
 	</div>
 
 	<!-- Todo Modal -->
-	<TodoModal bind:show={showModal} todo={editingTodo} on:save={() => todos.load({ status: 'pending' })} />
+	<TodoModal bind:this={todoModal} />
 
 	<!-- List View -->
 	{#if currentView === 'list'}

--- a/frontend/src/routes/projects/+page.svelte
+++ b/frontend/src/routes/projects/+page.svelte
@@ -8,7 +8,7 @@
 	let editingProject: Project | null = null;
 
 	onMount(async () => {
-		await projects.loadProjects();
+		await projects.load();
 	});
 
 	function openEditModal(project: Project) {
@@ -29,7 +29,7 @@
 <main class="container py-8">
 	<h1 class="text-3xl font-bold text-gray-900 mb-8">Manage Projects</h1>
 
-	<ProjectModal bind:show={showModal} project={editingProject} on:save={() => projects.loadProjects()} />
+	<ProjectModal bind:show={showModal} project={editingProject} on:save={() => projects.load()} />
 
 	<!-- Existing Projects -->
 	<div class="max-w-4xl mx-auto">


### PR DESCRIPTION
## Summary
Fixes multiple issues with the SvelteKit frontend that prevented proper functionality in development mode while working correctly in production:

- Double-click editing on calendar tasks now opens the edit modal
- Development environment properly connects to backend at localhost:8000
- Projects page loads correctly in dev mode
- Navigation menu displays properly in dev mode

## Changes

### Calendar Edit Functionality
- Connected `TodoModal` component properly using component reference (`bind:this`) instead of prop-based state management
- Removed unused `editingTodo` and `showModal` state variables
- Calendar's double-click handler now correctly triggers `todoModal.openEdit(todo)`

### Development Environment Configuration
- Added `BACKEND_URL` environment variable support in `+layout.server.ts`
- Created `.env` file for development with `BACKEND_URL=http://localhost:8000`
- Updated `.env.example` to reflect new environment variable
- Created `.env.production` with Docker-specific backend URL (`http://backend:8000`)
- Updated `.gitignore` to track `.env.production` for deployment consistency

### Projects Store API Response Handling
- Fixed projects store to correctly parse `{"data": [...], "meta": {...}}` response format
- Added support for both wrapped and unwrapped array formats for backward compatibility
- Corrected method name from `loadProjects()` to `load()` throughout codebase

## Testing
- [x] Dev server loads navigation menu and user info
- [x] Double-click on calendar tasks opens edit modal
- [x] Projects page loads correctly in dev mode
- [x] Production build works correctly
- [x] Docker containers work with updated configuration

## Test plan
- Start dev server with `npm run dev` and verify:
  - Full navigation menu appears
  - Projects page loads without errors
  - Double-clicking calendar tasks opens edit modal with task data pre-filled
- Build and run production Docker containers
- Verify both environments work identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)