### PR TITLE
Fix frontend Docker build and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,14 +88,14 @@ repos:
     hooks:
       - id: npm-audit
         name: npm audit (frontend)
-        entry: bash -c 'cd services/frontend && npm audit --production --audit-level=high'
+        entry: bash -c 'source $HOME/.nvm/nvm.sh && cd services/frontend && npm audit --production --audit-level=high'
         language: system
         files: ^services/frontend/(package\.json|package-lock\.json)$
         pass_filenames: false
 
       - id: npm-lint
         name: npm lint (frontend)
-        entry: bash -c 'cd services/frontend && npm run format'
+        entry: bash -c 'source $HOME/.nvm/nvm.sh && cd services/frontend && npm run format'
         language: system
         files: ^services/frontend/.*\.(js|ts|svelte)$
         pass_filenames: false

--- a/services/frontend/.env.production
+++ b/services/frontend/.env.production
@@ -7,3 +7,6 @@ BACKEND_URL=http://backend:8000
 
 # Application name (public variable, safe to include in build)
 PUBLIC_APP_NAME=TaskManager
+
+# Whether registration requires a registration code
+PUBLIC_REGISTRATION_CODE_REQUIRED=true

--- a/services/frontend/scripts/README.md
+++ b/services/frontend/scripts/README.md
@@ -13,17 +13,20 @@ The staging environment (`todo-stage.brooksmcmillin.com`) uses certificates from
 Fetches a new certificate from the Step CA ACME server and installs it to `.certs/`.
 
 **Usage:**
+
 ```bash
 ./scripts/fetch-certs.sh
 ```
 
 **Requirements:**
+
 - `certbot` must be installed
 - Port 80 must be available (no web server running)
 - Domain must resolve to this machine via DNS
 - Step CA ACME server must be accessible at `https://certs.lan`
 
 **What it does:**
+
 1. Uses certbot with standalone mode to get a certificate
 2. Validates domain ownership via HTTP-01 challenge on port 80
 3. Copies certificate files to `.certs/cert.pem` and `.certs/key.pem`
@@ -34,11 +37,13 @@ Fetches a new certificate from the Step CA ACME server and installs it to `.cert
 Wrapper script that fetches certificates (if needed) and starts the dev server.
 
 **Usage:**
+
 ```bash
 npm run dev:stage
 ```
 
 **What it does:**
+
 1. Checks if certificate exists and is valid for at least 1 hour
 2. Fetches a new certificate if needed or expiring soon
 3. Starts the Vite dev server
@@ -46,6 +51,7 @@ npm run dev:stage
 ### Setup
 
 1. **Install certbot:**
+
    ```bash
    # macOS
    brew install certbot
@@ -59,9 +65,11 @@ npm run dev:stage
    - Test: `dig todo-stage.brooksmcmillin.com` or `nslookup todo-stage.brooksmcmillin.com`
 
 3. **Update hosts file** (if using local DNS):
+
    ```bash
    sudo nano /etc/hosts
    ```
+
    Add: `10.0.13.55  todo-stage.brooksmcmillin.com`
 
 4. **Start development:**
@@ -73,18 +81,22 @@ npm run dev:stage
 ### Troubleshooting
 
 **"certbot not found"**
+
 - Install certbot (see Setup above)
 
 **"Address already in use" or port 80 errors**
+
 - Another service is using port 80
 - Stop any running web servers: `sudo lsof -i :80`
 
 **"Failed to fetch certificate"**
+
 - Check DNS resolution: `dig todo-stage.brooksmcmillin.com`
 - Verify Step CA is accessible: `curl https://certs.lan/acme/acme/directory`
 - Check firewall rules allow inbound port 80
 
 **Certificate validation issues**
+
 - Ensure domain resolves to this machine's IP (10.0.13.55)
 - Check that Step CA can reach this machine on port 80
 

--- a/services/frontend/vite.config.ts
+++ b/services/frontend/vite.config.ts
@@ -3,16 +3,24 @@ import { defineConfig } from 'vite';
 import fs from 'fs';
 import path from 'path';
 
+// Check if certificate files exist (for local dev with HTTPS)
+const certsPath = path.resolve(__dirname, '.certs');
+const keyPath = path.join(certsPath, 'key.pem');
+const certPath = path.join(certsPath, 'cert.pem');
+const hasCerts = fs.existsSync(keyPath) && fs.existsSync(certPath);
+
 export default defineConfig({
 	plugins: [sveltekit()],
 	server: {
 		host: '0.0.0.0',
 		port: 3000,
 		allowedHosts: ['todo-stage.brooksmcmillin.com'],
-		https: {
-			key: fs.readFileSync(path.resolve(__dirname, '.certs/key.pem')),
-			cert: fs.readFileSync(path.resolve(__dirname, '.certs/cert.pem'))
-		},
+		...(hasCerts && {
+			https: {
+				key: fs.readFileSync(keyPath),
+				cert: fs.readFileSync(certPath)
+			}
+		}),
 		proxy: {
 			'/api': {
 				target: process.env.VITE_API_URL || 'http://localhost:8000',


### PR DESCRIPTION
## Summary
- Fixed Docker build failure by making vite.config.ts HTTPS configuration conditional on certificate files existing
- Added missing `PUBLIC_REGISTRATION_CODE_REQUIRED` environment variable to `.env.production`
- Fixed pre-commit npm hooks to properly source nvm environment

## Problem
The frontend Docker build was failing with two issues:
1. `vite.config.ts` was unconditionally trying to read SSL certificate files that don't exist in the Docker build context
2. `PUBLIC_REGISTRATION_CODE_REQUIRED` static import was failing because the variable wasn't defined in `.env.production`
3. Pre-commit npm hooks were failing with "npm: command not found" because nvm wasn't loaded in the non-login shell

## Solution
1. Made HTTPS configuration in `vite.config.ts` conditional - only loads certs if they exist
2. Added `PUBLIC_REGISTRATION_CODE_REQUIRED=true` to `.env.production`
3. Updated pre-commit hooks to source nvm before running npm commands

## Testing
- Docker build now succeeds: `docker compose build frontend`
- Pre-commit hooks now pass: `pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)