### PR TITLE
Upgrade cookie dependency to 0.7.2 with npm overrides

### DIFF
--- a/services/frontend/package-lock.json
+++ b/services/frontend/package-lock.json
@@ -1499,9 +1499,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -3,6 +3,9 @@
 	"version": "1.0.0",
 	"private": true,
 	"type": "module",
+	"overrides": {
+		"cookie": "^0.7.0"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"dev:stage": "./scripts/dev-with-certs.sh",


### PR DESCRIPTION
## Summary
Upgrades the `cookie` package from version 0.6.0 to 0.7.2 in the frontend service and adds an npm override to enforce this version across the dependency tree.

## Changes
- Updated `cookie` package to version 0.7.2 in `package-lock.json`
- Added `overrides` field in `package.json` to pin `cookie` to `^0.7.0`, ensuring all transitive dependencies use this version or higher

## Details
This change uses npm's `overrides` feature (available in npm 8.3.0+) to enforce a consistent version of the `cookie` package across the entire dependency tree. This is useful for:
- Ensuring security patches are applied consistently
- Preventing version conflicts from transitive dependencies
- Maintaining compatibility with the rest of the application

https://claude.ai/code/session_01A5YSDtRYbC9sXx7hy3gVH4