### PR TITLE
Fix deployment workflow by removing host dependency installation

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -75,24 +75,6 @@ jobs:
             git log -1 --oneline
           EOF
 
-      - name: Install dependencies
-        run: |
-          echo "📦 Installing dependencies..."
-          ssh -i ~/.ssh/deploy_key \
-            ${{ secrets.PRODUCTION_USER }}@${{ secrets.PRODUCTION_HOST }} << 'EOF'
-            cd ${{ secrets.PRODUCTION_DEPLOY_PATH }}
-
-            # Backend dependencies
-            cd services/backend && uv sync --no-dev && cd ../..
-
-            # Frontend dependencies
-            cd services/frontend && npm ci --production && cd ../..
-
-            # MCP services (if needed)
-            cd services/mcp-auth && uv sync --no-dev && cd ../..
-            cd services/mcp-resource && uv sync --no-dev && cd ../..
-          EOF
-
       - name: Run database migrations
         if: ${{ !inputs.skip_migrations }}
         run: |
@@ -100,7 +82,7 @@ jobs:
           ssh -i ~/.ssh/deploy_key \
             ${{ secrets.PRODUCTION_USER }}@${{ secrets.PRODUCTION_HOST }} << 'EOF'
             cd ${{ secrets.PRODUCTION_DEPLOY_PATH }}
-            make migrate
+            docker compose run --rm backend alembic upgrade head
           EOF
 
       - name: Rebuild and restart services


### PR DESCRIPTION
## Summary
- Removes redundant "Install dependencies" step that required `uv` on the production host
- Updates database migrations to run inside Docker container
- Fixes deployment failure: `zsh: command not found: uv`

## Changes
1. **Removed "Install dependencies" step** - Dependencies are already installed during `docker compose build` (see backend/Dockerfile:14)
2. **Updated migrations** - Changed from `make migrate` to `docker compose run --rm backend alembic upgrade head`

## Why
The previous workflow tried to install dependencies on the host using `uv`, which:
- Wasn't installed on the production server
- Was unnecessary since Docker builds handle dependency installation

## Testing the workflow from this PR branch

You can test this workflow **without merging** by:

1. Go to **Actions** tab in GitHub
2. Select **"Deploy to Production"** workflow
3. Click **"Run workflow"** button
4. Change the branch dropdown from `main` to `fix/deployment-workflow-uv-dependency`
5. Type "deploy" to confirm
6. Click **"Run workflow"**

This will test the updated workflow from this PR branch before merging.

## Test plan
- [ ] Run deployment workflow from this branch (see instructions above)
- [ ] Verify migrations run successfully inside Docker
- [ ] Verify services rebuild and restart correctly
- [ ] Verify health checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)