### PR TITLE
Add Lakera Guard project ID to API requests

### DIFF
--- a/packages/mcp-resource-framework/mcp_resource_framework/security/lakera_guard.py
+++ b/packages/mcp-resource-framework/mcp_resource_framework/security/lakera_guard.py
@@ -58,6 +58,7 @@ async def screen_content(text: str, role: str = "user") -> dict[str, Any]:
             json={
                 "messages": [{"role": role, "content": text}],
                 "breakdown": True,
+                "project_id": "project-9146177048",
             },
             headers={
                 "Authorization": f"Bearer {LAKERA_API_KEY}",

--- a/services/mcp-resource/tests/test_lakera_guard.py
+++ b/services/mcp-resource/tests/test_lakera_guard.py
@@ -146,6 +146,7 @@ class TestScreenContent:
                 json={
                     "messages": [{"role": "user", "content": "test content"}],
                     "breakdown": True,
+                    "project_id": "project-9146177048",
                 },
                 headers={
                     "Authorization": "Bearer test-api-key",


### PR DESCRIPTION
## Summary
Updates all Lakera Guard API calls to include the project ID `project-9146177048` in the request payload for proper project tracking and analytics.

## Changes
- Added `project_id` parameter to `screen_content` function in lakera_guard.py
- Updated test expectations to validate project_id inclusion
- All 24 Lakera Guard tests passing

## Test Plan
- [x] Run Lakera Guard test suite - all tests pass
- [x] Verify API call includes correct project_id parameter
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)