### PR TITLE
Modernize frontend styling with dark mode support

### DIFF
--- a/services/frontend/src/app.scss
+++ b/services/frontend/src/app.scss
@@ -77,11 +77,22 @@
 	--bg-card: #ffffff;
 	--bg-input: #ffffff;
 	--bg-nav: #ffffff;
+	--bg-hover: var(--gray-100);
+	--bg-active: var(--gray-200);
+	--bg-overlay: rgba(0, 0, 0, 0.5);
+	--dropdown-bg: var(--bg-card);
+	--tag-bg: var(--gray-200);
+	--tag-text: var(--gray-700);
 	--text-primary: var(--gray-900);
 	--text-secondary: var(--gray-600);
 	--text-muted: var(--gray-500);
 	--border-color: var(--gray-200);
 	--border-light: var(--gray-100);
+
+	/* Transitions */
+	--transition-fast: 150ms ease;
+	--transition-base: 200ms ease;
+	--transition-slow: 300ms ease;
 }
 
 /* Dark mode theme */
@@ -114,6 +125,12 @@
 	--bg-card: #1f2937;
 	--bg-input: #374151;
 	--bg-nav: #1f2937;
+	--bg-hover: #374151;
+	--bg-active: #4b5563;
+	--bg-overlay: rgba(0, 0, 0, 0.7);
+	--dropdown-bg: #1f2937;
+	--tag-bg: #374151;
+	--tag-text: #d1d5db;
 	--text-primary: #f9fafb;
 	--text-secondary: #d1d5db;
 	--text-muted: #9ca3af;
@@ -578,7 +595,11 @@ h6 {
 	cursor: pointer;
 	text-decoration: none;
 	line-height: 1.25rem;
-	margin-left: 0.75rem;
+
+	// Adjacent button spacing
+	& + & {
+		margin-left: var(--space-3);
+	}
 
 	&:disabled {
 		opacity: 0.5;
@@ -1054,9 +1075,9 @@ h6 {
 	}
 
 	&.low-priority {
-		border-right: 2px solid var(--gray-40);
-		border-top: 2px solid var(--gray-40);
-		border-bottom: 2px solid var(--gray-40);
+		border-right: 2px solid var(--gray-400);
+		border-top: 2px solid var(--gray-400);
+		border-bottom: 2px solid var(--gray-400);
 	}
 
 	// Default priority styling
@@ -1231,6 +1252,24 @@ h6 {
 .project-filter-select {
 	flex: 1;
 	min-width: 0;
+}
+
+// Shared detail styles (used in TaskDetailPanel, TodoForm, etc.)
+.detail-label {
+	display: block;
+	font-size: 0.6875rem;
+	font-weight: 700;
+	color: var(--text-secondary);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	margin-bottom: 0.5rem;
+}
+
+.detail-text {
+	color: var(--text-primary);
+	font-size: 0.875rem;
+	line-height: 1.5;
+	white-space: pre-wrap;
 }
 
 // Print styles

--- a/services/frontend/src/lib/components/AttachmentList.svelte
+++ b/services/frontend/src/lib/components/AttachmentList.svelte
@@ -142,7 +142,7 @@
 	.attachment-list {
 		margin-top: 1.5rem;
 		padding-top: 1.5rem;
-		border-top: 1px solid #e5e7eb;
+		border-top: 1px solid var(--border-color);
 	}
 
 	.attachment-header {
@@ -155,7 +155,7 @@
 	.attachment-title {
 		font-size: 0.875rem;
 		font-weight: 600;
-		color: #374151;
+		color: var(--text-secondary);
 		margin: 0;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
@@ -163,7 +163,7 @@
 
 	.attachment-count {
 		font-weight: 400;
-		color: #6b7280;
+		color: var(--text-muted);
 		margin-left: 0.5rem;
 	}
 
@@ -171,21 +171,21 @@
 		width: 1.75rem;
 		height: 1.75rem;
 		border-radius: 50%;
-		border: 1px dashed #9ca3af;
+		border: 1px dashed var(--gray-400);
 		background: transparent;
-		color: #6b7280;
+		color: var(--text-muted);
 		font-size: 1.25rem;
 		cursor: pointer;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		transition: all 0.2s;
+		transition: all var(--transition-base);
 	}
 
 	.add-attachment-btn:hover:not(:disabled) {
-		border-color: #3b82f6;
-		color: #3b82f6;
-		background-color: #eff6ff;
+		border-color: var(--primary-500);
+		color: var(--primary-500);
+		background-color: var(--primary-50);
 	}
 
 	.add-attachment-btn:disabled {
@@ -206,8 +206,8 @@
 	.spinner {
 		width: 1rem;
 		height: 1rem;
-		border: 2px solid #e5e7eb;
-		border-top-color: #3b82f6;
+		border: 2px solid var(--border-color);
+		border-top-color: var(--primary-500);
 		border-radius: 50%;
 		animation: spin 0.8s linear infinite;
 	}
@@ -219,9 +219,9 @@
 	}
 
 	.error-message {
-		background-color: #fef2f2;
-		border: 1px solid #fecaca;
-		color: #dc2626;
+		background-color: var(--error-50);
+		border: 1px solid var(--error-100);
+		color: var(--error-600);
 		padding: 0.5rem 0.75rem;
 		border-radius: 0.375rem;
 		font-size: 0.875rem;
@@ -236,10 +236,10 @@
 
 	.attachment-item {
 		position: relative;
-		background-color: #f9fafb;
+		background-color: var(--bg-page);
 		border-radius: 0.5rem;
 		overflow: hidden;
-		border: 1px solid #e5e7eb;
+		border: 1px solid var(--border-color);
 	}
 
 	.attachment-preview {
@@ -247,7 +247,7 @@
 		aspect-ratio: 1;
 		padding: 0;
 		border: none;
-		background: #f3f4f6;
+		background: var(--bg-hover);
 		cursor: pointer;
 		display: block;
 	}
@@ -269,7 +269,7 @@
 	.attachment-name {
 		display: block;
 		font-size: 0.75rem;
-		color: #374151;
+		color: var(--text-primary);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -277,7 +277,7 @@
 
 	.attachment-size {
 		font-size: 0.625rem;
-		color: #9ca3af;
+		color: var(--text-muted);
 	}
 
 	.delete-btn {
@@ -287,15 +287,15 @@
 		width: 1.5rem;
 		height: 1.5rem;
 		border: none;
-		background: rgba(255, 255, 255, 0.9);
-		color: #6b7280;
+		background: var(--bg-card);
+		color: var(--text-muted);
 		cursor: pointer;
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		border-radius: 0.25rem;
 		opacity: 0;
-		transition: all 0.2s;
+		transition: all var(--transition-base);
 	}
 
 	.attachment-item:hover .delete-btn {
@@ -303,8 +303,8 @@
 	}
 
 	.delete-btn:hover {
-		color: #ef4444;
-		background: white;
+		color: var(--error-500);
+		background: var(--bg-card);
 	}
 
 	.delete-btn svg {
@@ -314,7 +314,7 @@
 
 	.no-attachments {
 		font-size: 0.875rem;
-		color: #9ca3af;
+		color: var(--text-muted);
 		text-align: center;
 		padding: 1rem 0;
 		margin: 0;

--- a/services/frontend/src/lib/components/Navigation.svelte
+++ b/services/frontend/src/lib/components/Navigation.svelte
@@ -315,12 +315,10 @@
 		left: 0;
 		margin-top: 0.5rem;
 		min-width: 10rem;
-		background-color: white;
+		background-color: var(--dropdown-bg);
 		border-radius: 0.5rem;
-		box-shadow:
-			0 10px 15px -3px rgba(0, 0, 0, 0.1),
-			0 4px 6px -2px rgba(0, 0, 0, 0.05);
-		border: 1px solid #e5e7eb;
+		box-shadow: var(--shadow-lg);
+		border: 1px solid var(--border-color);
 		overflow: hidden;
 		z-index: 50;
 		animation: slideDown 0.15s ease-out;
@@ -346,18 +344,18 @@
 		display: block;
 		padding: 0.5rem 1rem;
 		font-size: 0.875rem;
-		color: #374151;
+		color: var(--text-secondary);
 		text-decoration: none;
-		transition: background-color 0.15s ease-in-out;
+		transition: background-color var(--transition-fast);
 	}
 
 	.dropdown-item:hover {
-		background-color: #f3f4f6;
+		background-color: var(--bg-hover);
 	}
 
 	.dropdown-item.active {
-		background-color: #dbeafe;
-		color: #2563eb;
+		background-color: var(--primary-50);
+		color: var(--primary-600);
 		font-weight: 500;
 	}
 
@@ -372,14 +370,14 @@
 
 	.dropdown-header {
 		padding: 0.75rem 1rem 0.5rem 1rem;
-		color: #111827;
+		color: var(--text-primary);
 		font-size: 0.875rem;
 	}
 
 	.dropdown-divider {
 		height: 1px;
 		margin: 0.25rem 0;
-		background-color: #e5e7eb;
+		background-color: var(--border-color);
 	}
 
 	.user-dropdown {
@@ -395,53 +393,17 @@
 		background: none;
 		cursor: pointer;
 		border-radius: 9999px;
-		transition: background-color 0.15s ease-in-out;
-		color: #6b7280;
+		transition: background-color var(--transition-fast);
+		color: var(--text-muted);
 	}
 
 	.user-dropdown-trigger:hover {
-		background-color: #f3f4f6;
-		color: #111827;
+		background-color: var(--bg-hover);
+		color: var(--text-primary);
 	}
 
 	.user-icon {
 		width: 1.75rem;
 		height: 1.75rem;
-	}
-
-	/* Dark mode support */
-	:global(.dark) .dropdown-menu {
-		background-color: #1f2937;
-		border-color: #374151;
-	}
-
-	:global(.dark) .dropdown-item {
-		color: #d1d5db;
-	}
-
-	:global(.dark) .dropdown-item:hover {
-		background-color: #374151;
-	}
-
-	:global(.dark) .dropdown-item.active {
-		background-color: #1e3a8a;
-		color: #60a5fa;
-	}
-
-	:global(.dark) .dropdown-header {
-		color: #f3f4f6;
-	}
-
-	:global(.dark) .dropdown-divider {
-		background-color: #374151;
-	}
-
-	:global(.dark) .user-dropdown-trigger {
-		color: #9ca3af;
-	}
-
-	:global(.dark) .user-dropdown-trigger:hover {
-		background-color: #374151;
-		color: #f3f4f6;
 	}
 </style>

--- a/services/frontend/src/lib/components/SubtaskList.svelte
+++ b/services/frontend/src/lib/components/SubtaskList.svelte
@@ -171,7 +171,7 @@
 	.subtask-list {
 		margin-top: 1.5rem;
 		padding-top: 1.5rem;
-		border-top: 1px solid #e5e7eb;
+		border-top: 1px solid var(--border-color);
 	}
 
 	.subtask-header {
@@ -184,7 +184,7 @@
 	.subtask-title {
 		font-size: 0.875rem;
 		font-weight: 600;
-		color: #374151;
+		color: var(--text-secondary);
 		margin: 0;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
@@ -192,7 +192,7 @@
 
 	.subtask-count {
 		font-weight: 400;
-		color: #6b7280;
+		color: var(--text-muted);
 		margin-left: 0.5rem;
 	}
 
@@ -200,26 +200,26 @@
 		width: 1.75rem;
 		height: 1.75rem;
 		border-radius: 50%;
-		border: 1px dashed #9ca3af;
+		border: 1px dashed var(--gray-400);
 		background: transparent;
-		color: #6b7280;
+		color: var(--text-muted);
 		font-size: 1.25rem;
 		cursor: pointer;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		transition: all 0.2s;
+		transition: all var(--transition-base);
 	}
 
 	.add-subtask-btn:hover {
-		border-color: #3b82f6;
-		color: #3b82f6;
-		background-color: #eff6ff;
+		border-color: var(--primary-500);
+		color: var(--primary-500);
+		background-color: var(--primary-50);
 	}
 
 	.progress-bar {
 		height: 4px;
-		background-color: #e5e7eb;
+		background-color: var(--border-color);
 		border-radius: 2px;
 		margin-bottom: 1rem;
 		overflow: hidden;
@@ -233,7 +233,7 @@
 	}
 
 	.add-subtask-form {
-		background-color: #f9fafb;
+		background-color: var(--bg-page);
 		border-radius: 0.5rem;
 		padding: 0.75rem;
 		margin-bottom: 1rem;
@@ -248,23 +248,26 @@
 	.subtask-input {
 		flex: 1;
 		padding: 0.5rem 0.75rem;
-		border: 1px solid #d1d5db;
+		border: 1px solid var(--gray-300);
 		border-radius: 0.375rem;
 		font-size: 0.875rem;
+		background-color: var(--bg-input);
+		color: var(--text-primary);
 	}
 
 	.subtask-input:focus {
 		outline: none;
-		border-color: #3b82f6;
+		border-color: var(--primary-500);
 		box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 	}
 
 	.priority-select {
 		padding: 0.5rem;
-		border: 1px solid #d1d5db;
+		border: 1px solid var(--gray-300);
 		border-radius: 0.375rem;
 		font-size: 0.875rem;
-		background: white;
+		background: var(--bg-input);
+		color: var(--text-primary);
 	}
 
 	.form-actions {
@@ -280,7 +283,7 @@
 		font-weight: 500;
 		cursor: pointer;
 		border: none;
-		transition: all 0.2s;
+		transition: all var(--transition-base);
 	}
 
 	.btn-sm {
@@ -288,12 +291,12 @@
 	}
 
 	.btn-primary {
-		background-color: #3b82f6;
+		background-color: var(--primary-500);
 		color: white;
 	}
 
 	.btn-primary:hover:not(:disabled) {
-		background-color: #2563eb;
+		background-color: var(--primary-600);
 	}
 
 	.btn-primary:disabled {
@@ -302,12 +305,12 @@
 	}
 
 	.btn-secondary {
-		background-color: #e5e7eb;
-		color: #374151;
+		background-color: var(--bg-hover);
+		color: var(--text-primary);
 	}
 
 	.btn-secondary:hover {
-		background-color: #d1d5db;
+		background-color: var(--bg-active);
 	}
 
 	.subtask-items {
@@ -321,7 +324,7 @@
 		align-items: center;
 		gap: 0.75rem;
 		padding: 0.5rem 0;
-		border-bottom: 1px solid #f3f4f6;
+		border-bottom: 1px solid var(--border-light);
 	}
 
 	.subtask-item:last-child {
@@ -330,30 +333,30 @@
 
 	.subtask-item.completed .subtask-text {
 		text-decoration: line-through;
-		color: #9ca3af;
+		color: var(--text-muted);
 	}
 
 	.checkbox {
 		width: 1.25rem;
 		height: 1.25rem;
 		border-radius: 50%;
-		border: 2px solid #d1d5db;
-		background: white;
+		border: 2px solid var(--gray-300);
+		background: var(--bg-card);
 		cursor: pointer;
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		flex-shrink: 0;
-		transition: all 0.2s;
+		transition: all var(--transition-base);
 	}
 
 	.checkbox:hover:not(:disabled) {
-		border-color: #10b981;
+		border-color: var(--success-500);
 	}
 
 	.checkbox.checked {
-		background-color: #10b981;
-		border-color: #10b981;
+		background-color: var(--success-500);
+		border-color: var(--success-500);
 	}
 
 	.checkbox.checked svg {
@@ -376,7 +379,7 @@
 
 	.subtask-text {
 		font-size: 0.875rem;
-		color: #374151;
+		color: var(--text-primary);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -394,14 +397,14 @@
 		height: 1.5rem;
 		border: none;
 		background: transparent;
-		color: #9ca3af;
+		color: var(--text-muted);
 		cursor: pointer;
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		border-radius: 0.25rem;
 		opacity: 0;
-		transition: all 0.2s;
+		transition: all var(--transition-base);
 	}
 
 	.subtask-item:hover .delete-btn {
@@ -409,8 +412,8 @@
 	}
 
 	.delete-btn:hover {
-		color: #ef4444;
-		background-color: #fef2f2;
+		color: var(--error-500);
+		background-color: var(--error-50);
 	}
 
 	.delete-btn svg {
@@ -420,7 +423,7 @@
 
 	.no-subtasks {
 		font-size: 0.875rem;
-		color: #9ca3af;
+		color: var(--text-muted);
 		text-align: center;
 		padding: 1rem 0;
 		margin: 0;

--- a/services/frontend/src/lib/components/TaskDetailPanel.svelte
+++ b/services/frontend/src/lib/components/TaskDetailPanel.svelte
@@ -266,7 +266,7 @@
 		left: 0;
 		right: 0;
 		bottom: 0;
-		background-color: rgba(0, 0, 0, 0.5);
+		background-color: var(--bg-overlay);
 		z-index: 1000;
 		display: flex;
 		justify-content: flex-end;
@@ -283,12 +283,12 @@
 	}
 
 	.panel-container {
-		background: white;
+		background: var(--bg-card);
 		width: 100%;
 		max-width: 500px;
 		height: 100vh;
 		overflow-y: auto;
-		box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
+		box-shadow: var(--shadow-lg);
 		display: flex;
 		flex-direction: column;
 		animation: slideIn 0.3s ease-out;
@@ -305,20 +305,20 @@
 
 	.panel-header {
 		padding: 1.5rem;
-		border-bottom: 1px solid #e5e7eb;
+		border-bottom: 1px solid var(--border-color);
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
 		position: sticky;
 		top: 0;
-		background: white;
+		background: var(--bg-card);
 		z-index: 10;
 	}
 
 	.panel-header h2 {
 		font-size: 1.25rem;
 		font-weight: 600;
-		color: #111827;
+		color: var(--text-primary);
 		margin: 0;
 	}
 
@@ -327,7 +327,7 @@
 		background: none;
 		border: none;
 		font-size: 2rem;
-		color: #6b7280;
+		color: var(--text-muted);
 		cursor: pointer;
 		padding: 0;
 		width: 2rem;
@@ -336,13 +336,13 @@
 		align-items: center;
 		justify-content: center;
 		border-radius: 0.25rem;
-		transition: all 0.2s;
+		transition: all var(--transition-base);
 	}
 
 	.close-btn:hover,
 	.back-btn:hover {
-		background-color: #f3f4f6;
-		color: #111827;
+		background-color: var(--bg-hover);
+		color: var(--text-primary);
 	}
 
 	.back-btn {
@@ -364,14 +364,14 @@
 		display: block;
 		font-size: 0.6875rem;
 		font-weight: 700;
-		color: #374151;
+		color: var(--text-secondary);
 		text-transform: uppercase;
 		letter-spacing: 0.08em;
 		margin-bottom: 0.5rem;
 	}
 
 	.detail-text {
-		color: #374151;
+		color: var(--text-primary);
 		font-size: 0.875rem;
 		line-height: 1.5;
 		white-space: pre-wrap;
@@ -380,8 +380,8 @@
 	.tag {
 		display: inline-block;
 		padding: 0.25rem 0.75rem;
-		background-color: #e5e7eb;
-		color: #374151;
+		background-color: var(--tag-bg);
+		color: var(--tag-text);
 		font-size: 0.75rem;
 		border-radius: 9999px;
 		font-weight: 500;
@@ -389,10 +389,10 @@
 
 	.panel-footer {
 		padding: 1.5rem;
-		border-top: 1px solid #e5e7eb;
+		border-top: 1px solid var(--border-color);
 		display: flex;
 		gap: 0.75rem;
-		background: white;
+		background: var(--bg-card);
 		position: sticky;
 		bottom: 0;
 	}

--- a/services/frontend/src/lib/components/TodoForm.svelte
+++ b/services/frontend/src/lib/components/TodoForm.svelte
@@ -419,7 +419,7 @@
 		display: block;
 		font-size: 0.6875rem;
 		font-weight: 700;
-		color: #374151;
+		color: var(--text-secondary);
 		text-transform: uppercase;
 		letter-spacing: 0.08em;
 		margin-bottom: 0.5rem;
@@ -430,19 +430,19 @@
 	.form-select {
 		width: 100%;
 		padding: 0.5rem 0.75rem;
-		border: 1px solid #e5e7eb;
+		border: 1px solid var(--border-color);
 		border-radius: 0.375rem;
 		font-size: 0.875rem;
-		color: #374151;
-		background-color: white;
-		transition: border-color 0.15s ease-in-out;
+		color: var(--text-primary);
+		background-color: var(--bg-input);
+		transition: border-color var(--transition-fast);
 	}
 
 	.form-input:focus,
 	.form-textarea:focus,
 	.form-select:focus {
 		outline: none;
-		border-color: #2563eb;
+		border-color: var(--primary-500);
 		box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
 	}
 
@@ -453,7 +453,7 @@
 
 	.repeat-section {
 		padding-top: 1.5rem;
-		border-top: 1px solid #e5e7eb;
+		border-top: 1px solid var(--border-color);
 	}
 
 	.repeat-toggle {
@@ -476,7 +476,7 @@
 	.toggle-text {
 		font-size: 0.875rem;
 		font-weight: 500;
-		color: #374151;
+		color: var(--text-primary);
 	}
 
 	.repeat-options {
@@ -495,7 +495,7 @@
 
 	.interval-label {
 		font-size: 0.875rem;
-		color: #6b7280;
+		color: var(--text-muted);
 	}
 
 	.weekday-picker {
@@ -506,24 +506,24 @@
 
 	.weekday-btn {
 		padding: 0.5rem 0.75rem;
-		border: 1px solid #d1d5db;
+		border: 1px solid var(--gray-300);
 		border-radius: 0.375rem;
-		background-color: white;
+		background-color: var(--bg-input);
 		font-size: 0.75rem;
 		font-weight: 500;
-		color: #374151;
+		color: var(--text-primary);
 		cursor: pointer;
-		transition: all 0.15s ease-in-out;
+		transition: all var(--transition-fast);
 	}
 
 	.weekday-btn:hover {
-		border-color: #2563eb;
-		color: #2563eb;
+		border-color: var(--primary-500);
+		color: var(--primary-500);
 	}
 
 	.weekday-btn.selected {
-		background-color: #2563eb;
-		border-color: #2563eb;
+		background-color: var(--primary-600);
+		border-color: var(--primary-600);
 		color: white;
 	}
 
@@ -536,7 +536,7 @@
 		gap: 0.75rem;
 		margin-top: 2rem;
 		padding-top: 1.5rem;
-		border-top: 1px solid #e5e7eb;
+		border-top: 1px solid var(--border-color);
 	}
 
 	.form-actions .btn-primary {

--- a/services/frontend/src/routes/news/+page.svelte
+++ b/services/frontend/src/routes/news/+page.svelte
@@ -125,13 +125,13 @@
 </script>
 
 <div class="container mx-auto p-6">
-	<div class="mb-6">
-		<h1 class="text-3xl font-bold mb-2">AI/LLM Security News</h1>
-		<p class="text-gray-600">
+	<header class="page-header">
+		<h1>AI/LLM Security News</h1>
+		<p>
 			Stay updated with the latest security research, vulnerabilities, and best practices for AI and
 			large language models.
 		</p>
-	</div>
+	</header>
 
 	<!-- Filters and Search -->
 	<div class="flex gap-4 mb-6 items-center flex-wrap">
@@ -177,16 +177,16 @@
 			</form>
 		</div>
 
-		<div class="text-sm text-gray-600">
+		<div class="article-count">
 			{total}
 			{total === 1 ? 'article' : 'articles'}
 		</div>
 	</div>
 
 	<!-- Rating Legend -->
-	<div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
-		<h3 class="font-semibold mb-2">Rating Guide:</h3>
-		<ul class="text-sm space-y-1">
+	<div class="rating-guide">
+		<h3>Rating Guide:</h3>
+		<ul>
 			<li>
 				<strong>Good:</strong> High-quality content that's relevant and useful
 			</li>
@@ -197,20 +197,20 @@
 				<strong>Not Interested:</strong> Good quality but not relevant to your interests
 			</li>
 		</ul>
-		<p class="text-xs text-gray-600 mt-2">
+		<p class="rating-guide-note">
 			Your ratings help improve future article recommendations by adjusting source quality scores.
 		</p>
 	</div>
 
 	<!-- Articles List -->
 	{#if loading}
-		<div class="text-center py-12">
+		<div class="loading-state">
 			<div class="spinner"></div>
-			<p class="text-gray-600 mt-2">Loading articles...</p>
+			<p>Loading articles...</p>
 		</div>
 	{:else if articles.length === 0}
-		<div class="text-center py-12 bg-gray-50 rounded-lg">
-			<p class="text-gray-600">No articles found.</p>
+		<div class="empty-state">
+			<p>No articles found.</p>
 			{#if searchQuery || showUnreadOnly}
 				<button
 					onclick={() => {
@@ -257,7 +257,7 @@
 								{/if}
 							</div>
 
-							<div class="text-sm text-gray-600 mb-2">
+							<div class="article-meta">
 								<span class="font-medium">{article.feed_source_name}</span>
 								{#if article.author}
 									<span> • {article.author}</span>
@@ -266,7 +266,7 @@
 							</div>
 
 							{#if article.summary}
-								<p class="text-gray-700 mb-3 line-clamp-3">{article.summary}</p>
+								<p class="article-summary">{article.summary}</p>
 							{/if}
 
 							{#if article.keywords.length > 0}
@@ -334,11 +334,113 @@
 </div>
 
 <style>
+	/* Page Header */
+	.page-header {
+		margin-bottom: 2rem;
+		padding-bottom: 1.5rem;
+		border-bottom: 1px solid var(--border-color);
+	}
+
+	.page-header h1 {
+		font-size: 1.875rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		margin: 0 0 0.5rem 0;
+	}
+
+	.page-header p {
+		color: var(--text-secondary);
+		font-size: 1rem;
+		line-height: 1.5;
+		margin: 0;
+	}
+
+	/* Article count */
+	.article-count {
+		font-size: 0.875rem;
+		color: var(--text-muted);
+	}
+
+	/* Rating Guide */
+	.rating-guide {
+		background-color: var(--primary-50);
+		border: 1px solid var(--primary-200);
+		border-radius: var(--radius-lg);
+		padding: 1rem 1.25rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.rating-guide h3 {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0 0 0.5rem 0;
+	}
+
+	.rating-guide ul {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+	}
+
+	.rating-guide li {
+		margin-bottom: 0.25rem;
+	}
+
+	.rating-guide-note {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		margin: 0.5rem 0 0 0;
+	}
+
+	/* Loading State */
+	.loading-state {
+		text-align: center;
+		padding: 3rem 0;
+	}
+
+	.loading-state p {
+		color: var(--text-muted);
+		margin-top: 0.5rem;
+	}
+
+	/* Empty State */
+	.empty-state {
+		text-align: center;
+		padding: 3rem 0;
+		background-color: var(--bg-page);
+		border-radius: var(--radius-lg);
+	}
+
+	.empty-state p {
+		color: var(--text-muted);
+	}
+
+	/* Article Meta */
+	.article-meta {
+		font-size: 0.875rem;
+		color: var(--text-muted);
+		margin-bottom: 0.5rem;
+	}
+
+	/* Article Summary */
+	.article-summary {
+		color: var(--text-secondary);
+		margin-bottom: 0.75rem;
+		display: -webkit-box;
+		-webkit-line-clamp: 3;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	/* Spinner */
 	.spinner {
 		width: 48px;
 		height: 48px;
-		border: 4px solid #f3f4f6;
-		border-top: 4px solid #3b82f6;
+		border: 4px solid var(--border-color);
+		border-top: 4px solid var(--primary-500);
 		border-radius: 50%;
 		animation: spin 1s linear infinite;
 		margin: 0 auto;


### PR DESCRIPTION
## Summary

- Fix critical CSS bugs: invalid `--gray-40` variable, button margin issue
- Add new CSS variables for consistent dark mode theming
- Update components to use CSS variables instead of hardcoded colors
- Improve news page header styling with proper spacing

## Changes

### CSS Variables Added (`app.scss`)
- `--bg-hover`, `--bg-active`, `--bg-overlay` - interactive state backgrounds
- `--dropdown-bg` - dropdown menu background
- `--tag-bg`, `--tag-text` - tag styling
- `--transition-fast`, `--transition-base`, `--transition-slow` - animation timing

### Components Updated
- **Navigation.svelte** - Dropdown menus now use CSS variables for dark mode
- **TaskDetailPanel.svelte** - Panel backgrounds, borders, and text colors
- **TodoForm.svelte** - Form inputs, labels, and buttons
- **SubtaskList.svelte** - List items, checkboxes, and buttons
- **AttachmentList.svelte** - Attachment cards and delete buttons
- **news/+page.svelte** - Page header, rating guide, and article styling

### Bug Fixes
- Fixed invalid `--gray-40` CSS variable (should be `--gray-400`)
- Fixed button margin issue (removed default margin, added adjacent button spacing)

## Test plan

- [ ] Toggle dark mode on/off and verify all components render correctly
- [ ] Check Navigation dropdown menus in both themes
- [ ] Verify TaskDetailPanel styling in both themes
- [ ] Test form inputs and buttons in TodoForm
- [ ] Check news page header and article styling

🤖 Generated with [Claude Code](https://claude.ai/code)