### PR TITLE
Add feed type classification to news feed seeding

### DIFF
--- a/services/backend/scripts/seed_news_feeds.py
+++ b/services/backend/scripts/seed_news_feeds.py
@@ -5,68 +5,80 @@ import asyncio
 from sqlalchemy import select
 
 from app.db.database import async_session_maker
-from app.models.feed_source import FeedSource
+from app.models.feed_source import FeedSource, FeedType
 
 INITIAL_FEEDS = [
     {
         "name": "ArXiv CS.CR (Cryptography and Security)",
         "url": "http://export.arxiv.org/rss/cs.CR",
         "description": "Latest research papers on cryptography and security from ArXiv",
+        "type": FeedType.paper,
     },
     {
         "name": "ArXiv CS.AI (Artificial Intelligence)",
         "url": "http://export.arxiv.org/rss/cs.AI",
         "description": "Latest AI research papers from ArXiv",
+        "type": FeedType.paper,
     },
     {
         "name": "ArXiv CS.LG (Machine Learning)",
         "url": "http://export.arxiv.org/rss/cs.LG",
         "description": "Latest machine learning research papers from ArXiv",
+        "type": FeedType.paper,
     },
     {
         "name": "OWASP Blog",
         "url": "https://owasp.org/www-community/rss.xml",
         "description": "OWASP security community updates",
+        "type": FeedType.article,
     },
     {
         "name": "Google AI Blog",
         "url": "https://blog.research.google/atom.xml",
         "description": "Research and insights from Google AI",
+        "type": FeedType.article,
     },
     {
         "name": "OpenAI Blog",
         "url": "https://openai.com/blog/rss.xml",
         "description": "Latest updates and research from OpenAI",
+        "type": FeedType.article,
     },
     {
         "name": "Anthropic Blog",
         "url": "https://www.anthropic.com/news/rss.xml",
         "description": "Research and safety updates from Anthropic",
+        "type": FeedType.article,
     },
     {
         "name": "Trail of Bits Blog",
         "url": "https://blog.trailofbits.com/feed/",
         "description": "Security research and engineering insights",
+        "type": FeedType.article,
     },
     {
         "name": "NIST Cybersecurity Insights",
         "url": "https://www.nist.gov/blogs/cybersecurity-insights/rss.xml",
         "description": "NIST cybersecurity research and standards",
+        "type": FeedType.article,
     },
     {
         "name": "The Gradient",
         "url": "https://thegradient.pub/rss/",
         "description": "ML research news and perspectives",
+        "type": FeedType.article,
     },
     {
         "name": "Schneier on Security",
         "url": "https://www.schneier.com/feed/",
         "description": "Security expert Bruce Schneier's blog",
+        "type": FeedType.article,
     },
     {
         "name": "DeepMind Blog",
         "url": "https://deepmind.google/blog/rss.xml",
         "description": "AI research from Google DeepMind",
+        "type": FeedType.article,
     },
 ]
 
@@ -81,7 +93,14 @@ async def seed_feeds() -> None:
             existing_feed = result.scalar_one_or_none()
 
             if existing_feed:
-                print(f"✓ Feed already exists: {feed_data['name']}")
+                # Update type if it doesn't match
+                expected_type = feed_data.get("type", FeedType.article)
+                if existing_feed.type != expected_type:
+                    existing_feed.type = expected_type
+                    name = feed_data["name"]
+                    print(f"~ Updated type: {name} -> {expected_type.value}")
+                else:
+                    print(f"✓ Feed already exists: {feed_data['name']}")
                 continue
 
             # Create new feed source
@@ -89,6 +108,7 @@ async def seed_feeds() -> None:
                 name=feed_data["name"],
                 url=feed_data["url"],
                 description=feed_data.get("description"),
+                type=feed_data.get("type", FeedType.article),
                 is_active=True,
                 fetch_interval_hours=6,
                 quality_score=1.0,


### PR DESCRIPTION
## Summary
This PR adds feed type classification to the news feed seeding script, distinguishing between research papers and articles. It also implements logic to update existing feeds if their type needs to be corrected.

## Key Changes
- Import `FeedType` enum from `app.models.feed_source`
- Add `type` field to all 12 initial feed entries:
  - ArXiv feeds classified as `FeedType.paper`
  - Blog/news feeds classified as `FeedType.article`
- Update seed logic to handle existing feeds:
  - Check if existing feed's type matches expected type
  - Update type if mismatch is detected with informative logging
  - Skip update if type already matches
- Pass `type` parameter when creating new `FeedSource` instances with fallback to `FeedType.article`

## Implementation Details
- Existing feeds are now checked for type consistency during seeding
- Updated feeds are logged with `~` prefix to distinguish from new feeds (`✓`)
- Default type is `FeedType.article` for any feeds without explicit type specification
- Changes maintain backward compatibility with existing feed data

https://claude.ai/code/session_01Vmnbe2VxuEqP1t1sUeU6Dz