### PR TITLE
Add project creation and dependency management MCP tools

### DIFF
--- a/packages/taskmanager-sdk/taskmanager_sdk/client.py
+++ b/packages/taskmanager-sdk/taskmanager_sdk/client.py
@@ -530,6 +530,51 @@ class TaskManagerClient:
             "DELETE", f"/todos/{todo_id}/attachments/{attachment_id}"
         )
 
+    # Dependency methods
+    def get_dependencies(self, todo_id: int) -> ApiResponse:
+        """
+        Get all dependencies for a todo (tasks it depends on).
+
+        Args:
+            todo_id: Todo ID
+
+        Returns:
+            ApiResponse with list of dependency tasks
+        """
+        return self._make_request("GET", f"/todos/{todo_id}/dependencies")
+
+    def add_dependency(self, todo_id: int, dependency_id: int) -> ApiResponse:
+        """
+        Add a dependency to a todo.
+
+        The dependency_id specifies the task that must be completed before this task.
+
+        Args:
+            todo_id: Todo ID (the dependent task)
+            dependency_id: ID of the task this task depends on
+
+        Returns:
+            ApiResponse with created dependency data
+        """
+        return self._make_request(
+            "POST", f"/todos/{todo_id}/dependencies", {"dependency_id": dependency_id}
+        )
+
+    def remove_dependency(self, todo_id: int, dependency_id: int) -> ApiResponse:
+        """
+        Remove a dependency from a todo.
+
+        Args:
+            todo_id: Todo ID (the dependent task)
+            dependency_id: ID of the dependency task to remove
+
+        Returns:
+            ApiResponse with deletion result
+        """
+        return self._make_request(
+            "DELETE", f"/todos/{todo_id}/dependencies/{dependency_id}"
+        )
+
     # Category methods
     def get_categories(self) -> ApiResponse:
         """

--- a/packages/taskmanager-sdk/tests/test_client.py
+++ b/packages/taskmanager-sdk/tests/test_client.py
@@ -482,6 +482,76 @@ class TestTodos:
         assert call_args.kwargs["params"]["category"] == "Work"
 
 
+class TestDependencies:
+    """Test dependency management methods."""
+
+    def test_get_dependencies(
+        self, client: TaskManagerClient, mock_session: Mock
+    ) -> None:
+        """Test getting dependencies for a todo."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "id": 2,
+                    "title": "Blocking Task",
+                    "status": "pending",
+                    "priority": "high",
+                },
+            ],
+            "meta": {"count": 1},
+        }
+        mock_session.get.return_value = mock_response
+
+        result = client.get_dependencies(1)
+
+        assert result.success is True
+        mock_session.get.assert_called_once()
+        call_args = mock_session.get.call_args
+        assert "/todos/1/dependencies" in call_args.args[0]
+
+    def test_add_dependency(
+        self, client: TaskManagerClient, mock_session: Mock
+    ) -> None:
+        """Test adding a dependency to a todo."""
+        mock_response = Mock()
+        mock_response.status_code = 201
+        mock_response.headers = {}
+        mock_response.json.return_value = {
+            "data": {"id": 2, "title": "Blocking Task", "status": "pending"},
+        }
+        mock_session.post.return_value = mock_response
+
+        result = client.add_dependency(1, 2)
+
+        assert result.success is True
+        mock_session.post.assert_called_once()
+        call_args = mock_session.post.call_args
+        assert "/todos/1/dependencies" in call_args.args[0]
+        assert call_args.kwargs["json"]["dependency_id"] == 2
+
+    def test_remove_dependency(
+        self, client: TaskManagerClient, mock_session: Mock
+    ) -> None:
+        """Test removing a dependency from a todo."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.json.return_value = {
+            "data": {"deleted": True, "dependency_id": 2},
+        }
+        mock_session.delete.return_value = mock_response
+
+        result = client.remove_dependency(1, 2)
+
+        assert result.success is True
+        mock_session.delete.assert_called_once()
+        call_args = mock_session.delete.call_args
+        assert "/todos/1/dependencies/2" in call_args.args[0]
+
+
 class TestCategories:
     """Test category methods."""
 


### PR DESCRIPTION
## Summary
- Adds `create_project` MCP tool so projects can be created through the MCP interface (previously read-only via `get_categories`)
- Adds `list_dependencies`, `add_dependency`, and `remove_dependency` MCP tools exposing the backend's existing dependency management
- Adds corresponding SDK methods (`get_dependencies`, `add_dependency`, `remove_dependency`) to `TaskManagerClient`
- Adds unit tests for all new SDK methods and MCP tools

## Motivation
The MCP server lacked project creation and dependency management tools, making it impossible to fully represent structured task hierarchies (e.g., roadmap phases with inter-phase dependencies) through the MCP interface.

## Test plan
- [x] SDK tests pass (45/45) - `packages/taskmanager-sdk/tests/test_client.py`
- [x] MCP tools tests pass (66/66) - `services/mcp-resource/tests/test_mcp_tools.py`
- [x] Ruff lint clean on both packages
- [x] Pyright clean on SDK (MCP resource pyright has 13 pre-existing errors from stale SDK install, unrelated to this PR)
- [ ] Rebuild MCP resource Docker container and verify new tools appear
- [ ] Test create_project + add_dependency through MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)