### PR TITLE
Fix CIMD intercepting registered OAuth clients

### DIFF
--- a/services/mcp-auth/mcp_auth/auth_server.py
+++ b/services/mcp-auth/mcp_auth/auth_server.py
@@ -1198,12 +1198,9 @@ def create_authorization_server(
                 "token_endpoint_auth_methods_supported": [
                     "client_secret_post",
                     "none",
-                    "private_key_jwt",  # For CIMD confidential clients
                 ],
                 "code_challenge_methods_supported": ["S256"],
                 "scopes_supported": [auth_settings.mcp_scope],
-                # CIMD support (draft-ietf-oauth-client-id-metadata-document)
-                "client_id_metadata_document_supported": True,
             },
             headers={
                 "Access-Control-Allow-Origin": get_cors_origin(request),


### PR DESCRIPTION
## Summary
- CIMD discovery was checked first in `get_client()`, causing URL-based client_ids (like Claude mobile's `https://claude.ai/oauth/mcp-oauth-client-metadata`) to bypass dynamic registration and use CIMD metadata instead, breaking the auth flow
- Reordered `get_client()` so registered clients and backend lookups take priority, with CIMD as a fallback for truly unknown URL-based client_ids
- Removed `client_id_metadata_document_supported` and `private_key_jwt` from OAuth metadata so clients use dynamic registration until CIMD flow issues are resolved

## Test plan
- [x] All 49 mcp-auth tests pass
- [ ] Rebuild and restart `taskmanager-mcp-auth` container
- [ ] Verify Claude mobile auth flow opens and completes successfully
- [ ] Verify other MCP clients still authenticate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)