### PR TITLE
Add pyright to CI and trigger Claude reviews on PR updates

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      - name: Run pyright
+        run: uv run pyright app/
+
       - name: Run database migrations
         env:
           POSTGRES_USER: taskmanager

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   claude-review:

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -2,7 +2,7 @@ name: Claude Security Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   claude-security-review:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -39,6 +39,7 @@ jobs:
       working-directory: services/mcp-auth
       python-versions: '["3.13"]'
       skip-install-test: true
+      run-type-check: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -50,6 +51,7 @@ jobs:
       working-directory: services/mcp-resource
       python-versions: '["3.13"]'
       skip-install-test: true
+      run-type-check: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -60,5 +62,6 @@ jobs:
       package-name: taskmanager_sdk
       working-directory: packages/taskmanager-sdk
       python-versions: '["3.12", "3.13"]'
+      run-type-check: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/packages/taskmanager-sdk/pyproject.toml
+++ b/packages/taskmanager-sdk/pyproject.toml
@@ -59,6 +59,10 @@ taskmanager_sdk = ["py.typed"]
 [tool.ruff]
 exclude = ["build"]
 
+[tool.pyright]
+pythonVersion = "3.10"
+typeCheckingMode = "standard"
+
 [tool.mypy]
 python_version = "3.10"
 warn_return_any = true

--- a/services/mcp-auth/pyproject.toml
+++ b/services/mcp-auth/pyproject.toml
@@ -83,6 +83,10 @@ unfixable = []
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]
 
+[tool.pyright]
+pythonVersion = "3.13"
+typeCheckingMode = "standard"
+
 [tool.mypy]
 python_version = "3.13"
 warn_return_any = true

--- a/services/mcp-resource/pyproject.toml
+++ b/services/mcp-resource/pyproject.toml
@@ -79,6 +79,10 @@ unfixable = []
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]
 
+[tool.pyright]
+pythonVersion = "3.13"
+typeCheckingMode = "standard"
+
 [tool.mypy]
 python_version = "3.13"
 warn_return_any = true


### PR DESCRIPTION
## Summary
- Enable pyright type checking in all Python CI workflows (backend, mcp-auth, mcp-resource, SDK)
- Add `[tool.pyright]` config to pyproject.toml for services that were missing it
- Trigger Claude code review and security review workflows on `synchronize` events so they run when PRs are updated, not just when opened

## Test plan
- [ ] Verify backend-ci runs pyright step successfully
- [ ] Verify python-ci runs type-check job for mcp-auth, mcp-resource, and SDK
- [ ] Verify Claude review workflows trigger on PR push updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)