### PR TITLE
Fix mcp-resource Docker build: add missing mcp-auth-framework dependency

### DIFF
--- a/services/mcp-resource/Dockerfile
+++ b/services/mcp-resource/Dockerfile
@@ -18,6 +18,7 @@ ENV PATH="/root/.local/bin:$PATH"
 
 # Copy SDK and framework packages first (needed for local dependencies)
 COPY packages/taskmanager-sdk /packages/taskmanager-sdk
+COPY packages/mcp-auth-framework /packages/mcp-auth-framework
 COPY packages/mcp-resource-framework /packages/mcp-resource-framework
 
 # Copy dependency files
@@ -25,6 +26,7 @@ COPY services/mcp-resource/pyproject.toml ./
 
 # Update pyproject.toml to use absolute paths for Docker build, then install dependencies
 RUN sed -i 's|path = "../../packages/taskmanager-sdk"|path = "/packages/taskmanager-sdk"|' pyproject.toml \
+    && sed -i 's|path = "../../packages/mcp-auth-framework"|path = "/packages/mcp-auth-framework"|' pyproject.toml \
     && sed -i 's|path = "../../packages/mcp-resource-framework"|path = "/packages/mcp-resource-framework"|' pyproject.toml \
     && uv sync --no-dev
 


### PR DESCRIPTION
## Summary
- The `mcp-resource` Dockerfile was missing the `COPY` and `sed` path rewrite for the `mcp-auth-framework` package
- This caused `uv sync` to fail during Docker build with a path normalization error (`/app/../../packages/mcp-auth-framework`)
- Added the missing `COPY` and `sed` rewrite to match the three local dependencies in `pyproject.toml`

## Test plan
- [ ] Run `docker compose build mcp-resource` and verify it builds successfully
- [ ] Run `docker compose up` and verify mcp-resource starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)