### PR TITLE
Add feed source CRUD management and featured filter

### DIFF
--- a/services/backend/alembic/versions/0016_add_is_featured_to_feed_sources.py
+++ b/services/backend/alembic/versions/0016_add_is_featured_to_feed_sources.py
@@ -1,0 +1,32 @@
+"""Add is_featured column to feed_sources table.
+
+Revision ID: 0016_add_is_featured_to_feed_sources
+Revises: 0015_remove_username
+Create Date: 2026-02-13
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0016_add_is_featured_to_feed_sources"
+down_revision: str | None = "0015_remove_username"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "feed_sources",
+        sa.Column("is_featured", sa.Boolean(), nullable=True),
+    )
+    op.execute("UPDATE feed_sources SET is_featured = false")
+    op.alter_column("feed_sources", "is_featured", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("feed_sources", "is_featured")

--- a/services/backend/app/models/feed_source.py
+++ b/services/backend/app/models/feed_source.py
@@ -33,6 +33,7 @@ class FeedSource(Base):
     description: Mapped[str | None] = mapped_column(String(500))
     type: Mapped[FeedType] = mapped_column(String(20), default=FeedType.article)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    is_featured: Mapped[bool] = mapped_column(Boolean, default=False)
     fetch_interval_hours: Mapped[int] = mapped_column(Integer, default=6)
     last_fetched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     quality_score: Mapped[float] = mapped_column(default=1.0)

--- a/services/frontend/src/lib/components/FeedSourceForm.svelte
+++ b/services/frontend/src/lib/components/FeedSourceForm.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import { api } from '$lib/api/client';
+	import { toasts } from '$lib/stores/ui';
+	import type { FeedSource, FeedType } from '$lib/types';
+
+	export let editingSource: FeedSource | null = null;
+
+	const dispatch = createEventDispatcher();
+
+	let formData = {
+		name: '',
+		url: '',
+		description: '',
+		type: 'article' as FeedType,
+		is_active: true,
+		is_featured: false,
+		fetch_interval_hours: 6
+	};
+
+	$: isEditing = editingSource !== null;
+	$: submitButtonText = isEditing ? 'Update Source' : 'Create Source';
+
+	$: if (editingSource) {
+		formData = {
+			name: editingSource.name,
+			url: editingSource.url,
+			description: editingSource.description || '',
+			type: editingSource.type,
+			is_active: editingSource.is_active,
+			is_featured: editingSource.is_featured,
+			fetch_interval_hours: editingSource.fetch_interval_hours
+		};
+	}
+
+	export function reset() {
+		formData = {
+			name: '',
+			url: '',
+			description: '',
+			type: 'article',
+			is_active: true,
+			is_featured: false,
+			fetch_interval_hours: 6
+		};
+		editingSource = null;
+	}
+
+	async function handleSubmit() {
+		try {
+			const data = {
+				name: formData.name,
+				url: formData.url,
+				description: formData.description || undefined,
+				type: formData.type,
+				is_active: formData.is_active,
+				is_featured: formData.is_featured,
+				fetch_interval_hours: formData.fetch_interval_hours
+			};
+
+			if (isEditing && editingSource) {
+				await api.put(`/api/news/sources/${editingSource.id}`, data);
+				toasts.show('Feed source updated successfully', 'success');
+			} else {
+				await api.post('/api/news/sources', data);
+				toasts.show('Feed source created successfully', 'success');
+			}
+
+			reset();
+			dispatch('success');
+		} catch (error) {
+			toasts.show(
+				`Error ${isEditing ? 'updating' : 'creating'} feed source: ` +
+					(error as Error).message,
+				'error'
+			);
+		}
+	}
+
+	async function handleDelete() {
+		if (!editingSource) return;
+
+		const confirmDelete = confirm(
+			'Are you sure you want to delete this feed source? This will also delete all articles from this source. This action cannot be undone.'
+		);
+
+		if (!confirmDelete) return;
+
+		try {
+			await api.delete(`/api/news/sources/${editingSource.id}`);
+			toasts.show('Feed source deleted successfully', 'success');
+			reset();
+			dispatch('success');
+		} catch (error) {
+			toasts.show('Error deleting feed source: ' + (error as Error).message, 'error');
+		}
+	}
+</script>
+
+<div class="feed-source-form-container">
+	<form class="card" on:submit|preventDefault={handleSubmit}>
+		<div class="form-group">
+			<label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+			<input
+				type="text"
+				id="name"
+				name="name"
+				required
+				class="form-input mt-1"
+				bind:value={formData.name}
+			/>
+		</div>
+
+		<div class="form-group">
+			<label for="url" class="block text-sm font-medium text-gray-700">Feed URL</label>
+			<input
+				type="url"
+				id="url"
+				name="url"
+				required
+				class="form-input mt-1"
+				placeholder="https://example.com/feed.xml"
+				bind:value={formData.url}
+			/>
+		</div>
+
+		<div class="form-group">
+			<label for="description" class="block text-sm font-medium text-gray-700"
+				>Description</label
+			>
+			<textarea
+				id="description"
+				name="description"
+				rows="2"
+				class="form-textarea mt-1"
+				bind:value={formData.description}
+			></textarea>
+		</div>
+
+		<div class="form-group">
+			<label for="type" class="block text-sm font-medium text-gray-700">Type</label>
+			<select id="type" name="type" class="form-select mt-1" bind:value={formData.type}>
+				<option value="article">Article</option>
+				<option value="paper">Paper</option>
+			</select>
+		</div>
+
+		<div class="form-group">
+			<label for="fetch_interval_hours" class="block text-sm font-medium text-gray-700"
+				>Fetch Interval (hours)</label
+			>
+			<input
+				type="number"
+				id="fetch_interval_hours"
+				name="fetch_interval_hours"
+				min="1"
+				max="168"
+				class="form-input mt-1"
+				bind:value={formData.fetch_interval_hours}
+			/>
+		</div>
+
+		<div class="form-group flex items-center gap-6">
+			<label class="flex items-center gap-2 cursor-pointer">
+				<input type="checkbox" class="form-checkbox" bind:checked={formData.is_active} />
+				<span class="text-sm font-medium text-gray-700">Active</span>
+			</label>
+
+			<label class="flex items-center gap-2 cursor-pointer">
+				<input type="checkbox" class="form-checkbox" bind:checked={formData.is_featured} />
+				<span class="text-sm font-medium text-gray-700">Featured</span>
+			</label>
+		</div>
+
+		<div class="form-submit">
+			<div class="form-actions">
+				<button type="submit" class="btn btn-primary flex-1">{submitButtonText}</button>
+				{#if isEditing}
+					<button
+						type="button"
+						class="btn btn-danger btn-delete"
+						on:click={handleDelete}
+						title="Delete feed source"
+					>
+						Delete
+					</button>
+				{/if}
+			</div>
+		</div>
+	</form>
+</div>

--- a/services/frontend/src/lib/components/FeedSourceModal.svelte
+++ b/services/frontend/src/lib/components/FeedSourceModal.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import Modal from './Modal.svelte';
+	import FeedSourceForm from './FeedSourceForm.svelte';
+	import type { FeedSource } from '$lib/types';
+
+	const dispatch = createEventDispatcher();
+
+	let modal: Modal;
+	let feedSourceForm: FeedSourceForm;
+	let editingSource: FeedSource | null = null;
+	let modalTitle = 'Add Feed Source';
+
+	export function open() {
+		editingSource = null;
+		modalTitle = 'Add Feed Source';
+		if (feedSourceForm) feedSourceForm.reset();
+		modal.openModal();
+	}
+
+	export function openEdit(source: FeedSource) {
+		editingSource = source;
+		modalTitle = 'Edit Feed Source';
+		modal.openModal();
+	}
+
+	function handleSuccess() {
+		modal.closeModal();
+		if (feedSourceForm) feedSourceForm.reset();
+		dispatch('success');
+	}
+
+	function handleClose() {
+		if (feedSourceForm) feedSourceForm.reset();
+		editingSource = null;
+		modalTitle = 'Add Feed Source';
+	}
+</script>
+
+<Modal bind:this={modal} title={modalTitle} on:close={handleClose}>
+	<FeedSourceForm bind:this={feedSourceForm} bind:editingSource on:success={handleSuccess} />
+</Modal>

--- a/services/frontend/src/lib/components/Modal.svelte
+++ b/services/frontend/src/lib/components/Modal.svelte
@@ -7,7 +7,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	function closeModal() {
+	export function closeModal() {
 		show = false;
 		dispatch('close');
 		if (browser) {

--- a/services/frontend/src/lib/types.ts
+++ b/services/frontend/src/lib/types.ts
@@ -190,11 +190,24 @@ export interface FeedSource {
 	description: string | null;
 	type: FeedType;
 	is_active: boolean;
+	is_featured: boolean;
 	fetch_interval_hours: number;
 	last_fetched_at: string | null;
 	quality_score: number;
 	created_at: string;
 }
+
+export interface FeedSourceCreate {
+	name: string;
+	url: string;
+	description?: string;
+	type?: FeedType;
+	is_active?: boolean;
+	is_featured?: boolean;
+	fetch_interval_hours?: number;
+}
+
+export interface FeedSourceUpdate extends Partial<FeedSourceCreate> {}
 
 export type Frequency = 'daily' | 'weekly' | 'monthly' | 'yearly';
 


### PR DESCRIPTION
## Summary
- Add `is_featured` column to `feed_sources` table with alembic migration
- Add CRUD endpoints (`POST`, `PUT`, `DELETE`) for feed sources with duplicate name/URL validation
- Add `featured` query parameter filter to `GET /api/news/sources`
- Add `FeedSourceForm` and `FeedSourceModal` frontend components for create/edit/delete
- Update sources page with Featured/All Sources toggle filter, Add Source button, clickable edit, and featured badges
- Export `closeModal()` from `Modal.svelte` (was private, needed by modal wrappers)
- Remove bare `except Exception` / `traceback.print_exc()` from `list_feed_sources`

## Test plan
- [ ] Run `alembic upgrade head` to apply migration
- [ ] Navigate to `/news/sources` — default view shows only featured sources
- [ ] Toggle to "All Sources" to see all sources
- [ ] Click "Add Source" — fill form — verify source appears
- [ ] Click source name or Edit button — edit form — verify changes persist
- [ ] Delete a source — verify removal and article cascade
- [ ] Toggle featured on some sources — verify filter views update
- [ ] Verify existing activate/deactivate toggle still works
- [ ] Run `npm run check` — no new errors
- [ ] Run `uv run pytest tests/ -v` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)