### PR TITLE
Add ability to mark completed tasks as incomplete

### DIFF
--- a/services/backend/app/api/todos.py
+++ b/services/backend/app/api/todos.py
@@ -729,6 +729,10 @@ async def update_todo(
     for field, value in update_data.items():
         setattr(todo, field, value)
 
+    # Clear completed_date when status changes away from completed
+    if "status" in update_data and update_data["status"] != Status.completed:
+        todo.completed_date = None
+
     # Commit the changes
     await db.commit()
     await db.refresh(todo)

--- a/services/frontend/src/app.scss
+++ b/services/frontend/src/app.scss
@@ -677,6 +677,16 @@ h6 {
 		}
 	}
 
+	&.btn-warning {
+		background-color: var(--warning-600);
+		color: white;
+
+		&:hover:not(:disabled) {
+			background-color: var(--warning-700);
+			@include button-hover-effect;
+		}
+	}
+
 	&.btn-outline {
 		background-color: transparent;
 		color: var(--text-secondary);

--- a/services/frontend/src/routes/task/[id]/+page.svelte
+++ b/services/frontend/src/routes/task/[id]/+page.svelte
@@ -58,6 +58,17 @@
 		}
 	}
 
+	async function handleUncomplete() {
+		if (!todo) return;
+		try {
+			await todos.updateTodo(todo.id, { status: 'pending' });
+			toasts.show('Task marked as incomplete', 'success');
+			await loadTodo();
+		} catch (e) {
+			toasts.show('Failed to update task', 'error');
+		}
+	}
+
 	async function handleFormSuccess() {
 		await loadTodo();
 		mode = 'view';
@@ -264,6 +275,8 @@
 						<button class="btn btn-secondary" on:click={handleEdit}>Edit Task</button>
 						{#if todo.status === 'pending' || todo.status === 'in_progress'}
 							<button class="btn btn-success" on:click={handleComplete}>Mark Complete</button>
+						{:else if todo.status === 'completed'}
+							<button class="btn btn-warning" on:click={handleUncomplete}>Mark Incomplete</button>
 						{/if}
 					</div>
 				</div>


### PR DESCRIPTION
## Summary
- Add "Mark Incomplete" button on the task detail page for completed tasks, reverting status to pending
- Clear `completed_date` on the backend when a task's status changes away from completed
- Add `btn-warning` button style variant for the new action

## Test plan
- [ ] Navigate to a completed task's detail page and verify the "Mark Incomplete" button appears
- [ ] Click "Mark Incomplete" and verify the task status changes to pending and completed_date is cleared
- [ ] Verify "Mark Complete" still appears for pending/in_progress tasks
- [ ] Verify no button appears for cancelled tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)