### PR TITLE
Fix uv run permission errors in MCP Docker containers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,3 +122,12 @@ repos:
     hooks:
       - id: hadolint-docker
         args: ['--ignore', 'DL3008', '--ignore', 'DL3013']
+
+  - repo: local
+    hooks:
+      - id: docker-uv-no-sync
+        name: uv run --no-sync in Docker runtime commands
+        entry: ./scripts/check-docker-uv-run.sh
+        language: script
+        files: (Dockerfile|docker-compose\.yml)$
+        pass_filenames: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       context: .
       dockerfile: services/mcp-auth/Dockerfile
     container_name: taskmanager-mcp-auth
-    command: uv run python -m mcp_auth.auth_server --port 9000 --taskmanager-url http://backend:8000
+    command: uv run --no-sync python -m mcp_auth.auth_server --port 9000 --taskmanager-url http://backend:8000
     ports:
       - '9000:9000'
     environment:
@@ -102,7 +102,7 @@ services:
       context: .
       dockerfile: services/mcp-resource/Dockerfile
     container_name: taskmanager-mcp-resource
-    command: uv run python -m mcp_resource.server --port 8001 --auth-server http://mcp-auth:9000 --auth-server-public-url ${MCP_AUTH_SERVER_PUBLIC_URL:-http://localhost:9000}
+    command: uv run --no-sync python -m mcp_resource.server --port 8001 --auth-server http://mcp-auth:9000 --auth-server-public-url ${MCP_AUTH_SERVER_PUBLIC_URL:-http://localhost:9000}
     ports:
       - '8001:8001'
     environment:

--- a/scripts/check-docker-uv-run.sh
+++ b/scripts/check-docker-uv-run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Ensure all Docker runtime commands (CMD/ENTRYPOINT/command:) that use
+# "uv run" include --no-sync, preventing uv from trying to sync the
+# environment as a non-root user at container startup.
+
+set -euo pipefail
+
+err=0
+
+# Match both shell form (uv run) and JSON array form ("uv", "run")
+uv_run_pattern='uv[", ]+run'
+
+for f in $(find . -name Dockerfile); do
+  if grep -E "(CMD|ENTRYPOINT).*$uv_run_pattern" "$f" | grep -qv -- '--no-sync'; then
+    echo "$f: uv run in CMD/ENTRYPOINT must use --no-sync to avoid permission errors at runtime"
+    err=1
+  fi
+done
+
+if grep -E "command:.*$uv_run_pattern" docker-compose.yml 2>/dev/null | grep -qv -- '--no-sync'; then
+  echo "docker-compose.yml: uv run in command must use --no-sync"
+  err=1
+fi
+
+exit $err

--- a/services/mcp-auth/Dockerfile
+++ b/services/mcp-auth/Dockerfile
@@ -40,4 +40,4 @@ USER appuser
 EXPOSE 9000
 
 # Default command
-CMD ["uv", "run", "python", "-m", "mcp_auth.auth_server"]
+CMD ["uv", "run", "--no-sync", "python", "-m", "mcp_auth.auth_server"]

--- a/services/mcp-resource/Dockerfile
+++ b/services/mcp-resource/Dockerfile
@@ -42,4 +42,4 @@ USER appuser
 EXPOSE 8001
 
 # Default command
-CMD ["uv", "run", "python", "-m", "mcp_resource.server"]
+CMD ["uv", "run", "--no-sync", "python", "-m", "mcp_resource.server"]


### PR DESCRIPTION
## Summary
- Add `--no-sync` to `uv run` in MCP Dockerfiles (CMD) and docker-compose.yml (command) to prevent uv from trying to sync dev dependencies at runtime as a non-root user
- Add pre-commit hook (`scripts/check-docker-uv-run.sh`) that catches any `uv run` without `--no-sync` in Docker runtime commands (CMD, ENTRYPOINT, docker-compose command)

## Context
The mcp-auth and mcp-resource containers were crash-looping because `uv run` was attempting to sync the environment to match the lockfile (which includes dev dependencies like `asyncpg-stubs`, `ruff`, `pyright`). Since the `.venv` is created as root during the Docker build but the container runs as `appuser`, the sync fails with permission denied errors.

## Test plan
- [x] Verified `docker logs taskmanager-mcp-auth` no longer shows permission errors after rebuild
- [x] Pre-commit hook passes on fixed files
- [x] Pre-commit hook catches regressions in both Dockerfile JSON array format and docker-compose shell format

🤖 Generated with [Claude Code](https://claude.com/claude-code)