### PR TITLE
Minimize old review comments and use strikethrough for fixed items

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,16 +6,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -25,26 +19,84 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Minimize previous review comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+          MARKER="<!-- claude-code-review -->"
+
+          # Find the most recent comment containing our marker
+          COMMENT_NODE_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq "[.[] | select(.body | contains(\"${MARKER}\"))] | last | .node_id // empty" 2>/dev/null)
+
+          if [ -n "$COMMENT_NODE_ID" ]; then
+            echo "Minimizing previous code review comment: $COMMENT_NODE_ID"
+            gh api graphql -f query='
+              mutation {
+                minimizeComment(input: {subjectId: "'"$COMMENT_NODE_ID"'", classifier: OUTDATED}) {
+                  minimizedComment { isMinimized }
+                }
+              }' 2>/dev/null || echo "Warning: failed to minimize comment"
+          else
+            echo "No previous code review comment found"
+          fi
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            You are a code reviewer. Review this pull request for code quality, correctness, and maintainability.
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            Use the repository's CLAUDE.md for guidance on style and conventions.
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            ## Comment Marker
+
+            You MUST start your review comment with exactly this HTML comment on its own line:
+            `<!-- claude-code-review -->`
+
+            This marker is used to track and manage review comments across pushes. Do not omit it.
+
+            ## Reading Previous Feedback
+
+            Before writing your review, read all existing bot comments on this PR (including minimized ones) to understand what was previously flagged:
+
+            ```
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate --jq '.[] | select(.user.type == "Bot") | "\n--- Comment from \(.created_at) ---\n\(.body)"'
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" --paginate --jq '.[] | select(.user.type == "Bot") | "\n--- Comment on \(.path) from \(.created_at) ---\n\(.body)"'
+            ```
+
+            ## Formatting Rules
+
+            Compare the current code against previously flagged issues and categorize:
+
+            - **Previously flagged + now fixed** → show with ~~strikethrough~~ and a "Fixed" note
+            - **Previously flagged + still present** → reference briefly without re-explaining
+            - **New issues** → standard formatting with full explanation
+
+            Structure your review using these sections (omit any section that has no items):
+
+            ### Resolved
+            Items previously flagged that are now fixed, shown with ~~strikethrough~~. Example:
+            - ~~Missing error handling in `parse_config()`~~ — Fixed
+
+            ### Still Open
+            Previously flagged items that remain unaddressed. Reference only, no re-explanation.
+
+            ### New Issues
+            Newly discovered problems with full explanation.
+
+            If everything is clean and there are no issues in any category, post a short "All clear" message (still include the marker).
+
+            ## Review Focus Areas
+            - Correctness: logic errors, edge cases, error handling
+            - Maintainability: readability, structure, naming
+            - Style: consistency with project patterns
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -19,39 +19,87 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Minimize previous review comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+          MARKER="<!-- claude-security-review -->"
+
+          # Find the most recent comment containing our marker
+          COMMENT_NODE_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq "[.[] | select(.body | contains(\"${MARKER}\"))] | last | .node_id // empty" 2>/dev/null)
+
+          if [ -n "$COMMENT_NODE_ID" ]; then
+            echo "Minimizing previous security review comment: $COMMENT_NODE_ID"
+            gh api graphql -f query='
+              mutation {
+                minimizeComment(input: {subjectId: "'"$COMMENT_NODE_ID"'", classifier: OUTDATED}) {
+                  minimizedComment { isMinimized }
+                }
+              }' 2>/dev/null || echo "Warning: failed to minimize comment"
+          else
+            echo "No previous security review comment found"
+          fi
+
       - name: Run Claude Security Review
         id: claude-security-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Please perform a security-focused review of this pull request. Analyze the changes for:
-
-            **Security Concerns:**
-            - Authentication and authorization vulnerabilities
-            - Injection attacks (SQL, command, code injection)
-            - Sensitive data exposure (credentials, API keys, PII)
-            - Insecure dependencies or imports
-            - Path traversal or file access issues
-            - Improper input validation or sanitization
-            - Cryptographic weaknesses
-            - OAuth/token handling issues
-            - Race conditions or TOCTOU vulnerabilities
-
-            **Code Quality (security-relevant):**
-            - Error handling that might leak sensitive info
-            - Logging that might expose secrets
-            - Unsafe deserialization
-            - Resource exhaustion possibilities
+            You are a security reviewer. Review this pull request for security vulnerabilities and concerns.
 
             Use the repository's CLAUDE.md for guidance on the codebase architecture.
 
-            Be specific about any issues found, including file paths and line numbers.
-            If no security issues are found, briefly confirm the changes look safe.
+            ## Comment Marker
+
+            You MUST start your review comment with exactly this HTML comment on its own line:
+            `<!-- claude-security-review -->`
+
+            This marker is used to track and manage review comments across pushes. Do not omit it.
+
+            ## Reading Previous Feedback
+
+            Before writing your review, read all existing bot comments on this PR (including minimized ones) to understand what was previously flagged:
+
+            ```
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate --jq '.[] | select(.user.type == "Bot") | "\n--- Comment from \(.created_at) ---\n\(.body)"'
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" --paginate --jq '.[] | select(.user.type == "Bot") | "\n--- Comment on \(.path) from \(.created_at) ---\n\(.body)"'
+            ```
+
+            ## Formatting Rules
+
+            Compare the current code against previously flagged issues and categorize:
+
+            - **Previously flagged + now fixed** → show with ~~strikethrough~~ and a "Fixed" note
+            - **Previously flagged + still present** → reference briefly without re-explaining
+            - **New issues** → standard formatting with full explanation
+
+            Structure your review using these sections (omit any section that has no items):
+
+            ### Resolved
+            Items previously flagged that are now fixed, shown with ~~strikethrough~~. Example:
+            - ~~SQL injection risk in `query_users()`~~ — Fixed
+
+            ### Still Open
+            Previously flagged items that remain unaddressed. Reference only, no re-explanation.
+
+            ### New Issues
+            Newly discovered problems with full explanation.
+
+            If everything is clean and there are no issues in any category, post a short "All clear" message (still include the marker).
+
+            ## Security Review Focus Areas
+            - Injection vulnerabilities (SQL, command, XSS, template injection)
+            - Authentication and authorization issues
+            - Data exposure (secrets, PII in logs, information leakage)
+            - Input validation at system boundaries
+            - Dependency vulnerabilities
+            - SSRF, path traversal, and other OWASP Top 10 issues
 
             Use `gh pr comment` with your Bash tool to leave your security review as a comment on the PR.
 
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'


### PR DESCRIPTION
## Summary
- Each review workflow now embeds a unique HTML marker (`<!-- claude-code-review -->`, `<!-- claude-security-review -->`) in its comment
- Before Claude posts a new review, the previous marked comment is minimized as OUTDATED via GraphQL `minimizeComment`
- Prompts use strikethrough formatting for resolved items and structured Resolved / Still Open / New Issues sections
- Upgrades `pull-requests` permission from `read` to `write` (needed for minimize mutation)
- Adds `Bash(gh api:*)` to `claude_args` so Claude can read previous comments

Mirrors the same pattern applied to the agents repo in brooksmcmillin/agents#97.

## Test plan
- [x] Open a PR with a known issue
- [x] First push: verify Claude posts review with HTML marker
- [x] Fix the issue and push again
- [x] Verify old comment is minimized (collapsed as "outdated")
- [x] Verify new comment shows the fixed issue with ~~strikethrough~~ under "Resolved"
- [x] Verify code-review and security-review comments don't interfere (different markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)