### PR TITLE
Add featured feed toggle and task completion to /home

### DIFF
--- a/services/frontend/src/routes/task/[id]/+page.svelte
+++ b/services/frontend/src/routes/task/[id]/+page.svelte
@@ -22,10 +22,13 @@
 
 	$: todoId = parseInt($page.params.id ?? '0');
 
-	onMount(async () => {
-		await projects.load();
-		await loadTodo();
+	onMount(() => {
+		projects.load();
 	});
+
+	$: if (todoId) {
+		loadTodo();
+	}
 
 	async function loadTodo() {
 		loading = true;


### PR DESCRIPTION
## Summary
- Default the /home RSS feed to featured-only sources with a Featured/All Sources segmented toggle to switch
- Add inline task completion checkboxes (circular button with hover checkmark) that complete and remove tasks without navigating away
- Make the task detail page reactive to route param changes so SvelteKit navigation works correctly

## Test plan
- [x] Visit `/home` — feed panel should show "Featured" toggle active, displaying only featured-source articles
- [x] Click "All Sources" — should re-fetch and show all articles
- [x] Hover over a task's circular checkbox — should highlight green with a checkmark
- [x] Click the checkbox — task should complete and disappear from the list
- [x] Click the task title/row (not checkbox) — should still navigate to `/task/{id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)