### PR TITLE
Add estimated_hours param to update_task MCP tool

### DIFF
--- a/services/mcp-resource/mcp_resource/server.py
+++ b/services/mcp-resource/mcp_resource/server.py
@@ -573,6 +573,7 @@ def create_resource_server(
         priority: str | None = None,
         tags: list[str] | None = None,
         parent_id: str | None = None,
+        estimated_hours: float | None = None,
     ) -> str:
         """
         Update an existing task.
@@ -587,6 +588,7 @@ def create_resource_server(
             priority: New priority - one of "low", "medium", "high", "urgent" (optional)
             tags: New list of tags (optional)
             parent_id: New parent task ID to move task - format "task_123" or just "123" (optional)
+            estimated_hours: Estimated hours to complete (optional)
 
         Returns:
             JSON object with id, updated_fields list, and status confirming update
@@ -632,6 +634,8 @@ def create_resource_server(
                 updated_fields.append("tags")
             if parent_id is not None:
                 updated_fields.append("parent_id")
+            if estimated_hours is not None:
+                updated_fields.append("estimated_hours")
 
             # Use SDK method with parent_id support
             response = api_client.update_todo(
@@ -640,6 +644,7 @@ def create_resource_server(
                 description=description,
                 category=category,
                 priority=priority,
+                estimated_hours=estimated_hours,
                 status=status,
                 due_date=due_date,
                 tags=tags,


### PR DESCRIPTION
## Summary
- Expose `estimated_hours` parameter on the `update_task` MCP tool
- The SDK already supported it on `update_todo` but the MCP tool wasn't passing it through

## Details
This allows the task queue runner (in the agents repo) to write triage hour estimates back to tasks. The companion PR is https://github.com/brooksmcmillin/agents/pull/105.

## Test plan
- [x] Verified `update_task` with `estimated_hours` returns `updated_fields: ["estimated_hours"]`
- [x] Verified value persists and is returned by `get_task`
- [x] End-to-end tested with task queue runner dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)