### PR TITLE
Fix MCP auth: service account tokens and token commit race

### DIFF
--- a/services/backend/app/api/oauth/token.py
+++ b/services/backend/app/api/oauth/token.py
@@ -141,6 +141,9 @@ async def _handle_authorization_code(
         refresh_token_expires_at=get_token_expiry(settings.access_token_expiry * 24),
     )
     db.add(access_token)
+    # Commit now so the token is visible to immediate follow-up requests
+    # (e.g. MCP auth server verifying the token right after exchange)
+    await db.commit()
 
     # Deserialize scopes from JSON for response
     scopes_list = json.loads(auth_code.scopes)
@@ -190,6 +193,7 @@ async def _handle_refresh_token(
 
     # Delete old token
     await db.delete(old_token)
+    await db.commit()
 
     # Deserialize scopes from JSON for response
     scopes_list = json.loads(old_token.scopes)
@@ -250,6 +254,7 @@ async def _handle_client_credentials(
         expires_at=get_token_expiry(settings.access_token_expiry),
     )
     db.add(access_token)
+    await db.commit()
 
     return {
         "access_token": access_token.token,
@@ -335,6 +340,7 @@ async def _handle_device_code(db, client: OAuthClient, device_code: str | None) 
 
     # Delete device code
     await db.delete(dc)
+    await db.commit()
 
     # Deserialize scopes from JSON for response
     scopes_list = json.loads(dc.scopes)


### PR DESCRIPTION
## Summary
- **Service account token rejection**: `validate_client_credentials_token` rejected all tokens with a `user_id`, but service account tokens always carry one (by design from Phase 2). Updated to accept tokens from active service accounts while still rejecting regular user tokens.
- **Token commit race condition**: All four token grant handlers (`authorization_code`, `refresh_token`, `client_credentials`, `device_code`) relied on `get_db()` cleanup to commit, which runs after the response is sent. The MCP auth server verifies tokens immediately after exchange (~7ms gap), so the token wasn't yet committed to the DB. Added explicit `await db.commit()` in each handler.

## Test plan
- [x] Added test: service account token succeeds validation
- [x] Added test: inactive service account token is rejected
- [x] Existing test: regular user token still rejected
- [x] Existing test: system-level token (no user_id) still works
- [x] All 75 OAuth/dependency tests pass
- [x] Verified end-to-end: MCP auth server starts cleanly, client registration works, OAuth callback succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)