### PR TITLE
feat(api): support wiki page linking in batch task creation

### DIFF
--- a/packages/taskmanager-sdk/taskmanager_sdk/client.py
+++ b/packages/taskmanager-sdk/taskmanager_sdk/client.py
@@ -409,6 +409,7 @@ class TaskManagerClient:
     def batch_create_todos(
         self,
         todos: list[dict[str, Any]],
+        wiki_page_id: int | None = None,
     ) -> ApiResponse:
         """
         Create multiple todos in a single request.
@@ -418,11 +419,16 @@ class TaskManagerClient:
                    Supports the same fields as create_todo (description,
                    category, priority, due_date, deadline_type, tags,
                    parent_id, etc.)
+            wiki_page_id: Optional wiki page ID to auto-link to all
+                          created tasks.
 
         Returns:
             ApiResponse with list of created todos
         """
-        return self._make_request("POST", "/todos/batch", {"todos": todos})
+        data: dict[str, Any] = {"todos": todos}
+        if wiki_page_id is not None:
+            data["wiki_page_id"] = wiki_page_id
+        return self._make_request("POST", "/todos/batch", data)
 
     def get_todo(self, todo_id: int) -> ApiResponse:
         """

--- a/services/mcp-resource/mcp_resource/server.py
+++ b/services/mcp-resource/mcp_resource/server.py
@@ -587,6 +587,7 @@ def create_resource_server(
     @guard_tool(screen_output=True)
     async def create_tasks(
         tasks: list[dict[str, Any]],
+        wiki_page_id: int | None = None,
     ) -> str:
         """
         Create multiple tasks in a single request (batch creation).
@@ -614,6 +615,10 @@ def create_resource_server(
                 - parent_index (optional): 0-based index of another task in
                   this batch to use as parent. Mutually exclusive with
                   parent_id.
+            wiki_page_id: Optional wiki page ID to auto-link to all created tasks.
+                When provided, every task created in this batch is automatically
+                linked to the specified wiki page, eliminating the need for
+                separate link_wiki_page_to_task calls.
 
         Returns:
             JSON object with created task IDs and count
@@ -690,7 +695,7 @@ def create_resource_server(
                 todo_dicts.append(todo)
 
             api_client = get_api_client()
-            response = api_client.batch_create_todos(todo_dicts)
+            response = api_client.batch_create_todos(todo_dicts, wiki_page_id=wiki_page_id)
 
             created_tasks, list_error = validate_list_response(response, "batch created tasks")
             if list_error:
@@ -716,6 +721,9 @@ def create_resource_server(
                 "count": len(results),
                 "current_time": datetime.datetime.now(tz=datetime.UTC).isoformat(),
             }
+            if wiki_page_id is not None:
+                result["wiki_page_id"] = wiki_page_id
+                result["wiki_links_created"] = len(results)
             if warnings:
                 result["warnings"] = warnings
             return json.dumps(result)


### PR DESCRIPTION
## Summary
- Adds optional `wiki_page_id` parameter to the batch task creation endpoint (`POST /api/todos/batch`)
- When provided, all created tasks are automatically linked to the specified wiki page in a single request
- Eliminates the need for N separate `link_wiki_page_to_task` calls after batch creation
- Changes propagated across backend API, Python SDK, and MCP Resource Server

Closes task #444

## Test plan
- [x] Unit tests for batch creation with wiki_page_id (backend: 4 tests)
- [x] Test invalid wiki_page_id is rejected with 404
- [x] Verify links are created for all tasks in batch via linked-tasks endpoint
- [x] Verify backward compatibility (no wiki_page_id, null wiki_page_id)
- [x] SDK unit tests for wiki_page_id parameter passing (3 tests)
- [x] MCP tool tests for wiki_page_id parameter (2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)