### PR TITLE
feat: migrate from nginx to Traefik reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,6 +192,8 @@ services:
     networks:
       - taskmanager_network
       - proxy
+    labels:
+      - traefik.enable=false
 
   promtail:
     image: grafana/promtail:3.0.0


### PR DESCRIPTION
## Summary

- Replace nginx with Traefik v3.6 for automatic Docker service discovery, Let's Encrypt SSL, and version-controlled routing config
- Add Traefik labels to all public services (backend, frontend, mcp-auth, mcp-resource, mcp-relay) for automatic route registration via shared `proxy` network
- Remove host port bindings from public services; bind postgres and grafana to `127.0.0.1` only (SSH tunnel access)
- Explicitly opt Loki out of Traefik routing (`traefik.enable=false`) — it joins the proxy network only so the Traefik file-provider mTLS route can reach it

Companion changes in separate repos:
- `brooksmcmillin/infra` — Traefik container, shared middleware (`exposedByDefault: false`), file-provider routes, mTLS config, static site containers
- `brooksmcmillin/connections` — Join proxy network with Traefik labels
- `brooksmcmillin/django-football` — Join proxy network with Traefik labels

Also applied (not in this PR):
- Self-signed postgres SSL cert (10yr, replaces certbot renewal hook)
- Database migration 0023 (wiki_pages revision_number + deleted_at columns)

## Test plan

- [x] All domains resolve with valid TLS and security headers (HSTS, X-Frame-Options, X-Content-Type-Options)
- [x] Traefik healthcheck passing
- [x] todo.brooksmcmillin.com returns 200
- [x] api.brooksmcmillin.com routed to backend
- [x] mcp.brooksmcmillin.com, mcp-auth, mcp-relay all routed correctly
- [x] brooksmcmillin.com and slides.brooksmcmillin.com static sites serve
- [x] connections.brooksmcmillin.com returns 200
- [x] postgres accessible on 127.0.0.1:5432 only
- [x] grafana accessible on 127.0.0.1:3001 only
- [ ] Verify Let's Encrypt cert renewal (acme.json populates)
- [ ] Verify Jellyfin streaming once host is reachable
- [ ] Verify MCP CORS from browser devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)