### PR TITLE
fix(monitoring): expose Loki port locally and increase ingestion rate limits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,8 @@ services:
   loki:
     image: grafana/loki:3.0.0
     container_name: taskmanager-loki
+    ports:
+      - "127.0.0.1:3100:3100"
     restart: unless-stopped
     volumes:
       - ./services/monitoring/loki/loki-config.yml:/etc/loki/local-config.yaml:ro

--- a/services/monitoring/loki/loki-config.yml
+++ b/services/monitoring/loki/loki-config.yml
@@ -29,3 +29,7 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   allow_structured_metadata: false
+  ingestion_rate_mb: 16
+  ingestion_burst_size_mb: 32
+  per_stream_rate_limit: 10MB
+  per_stream_rate_limit_burst: 50MB


### PR DESCRIPTION
## Summary
- Bind Loki to `127.0.0.1:3100` in docker-compose for local debugging access (not exposed externally)
- Increase Loki ingestion rate limits (`ingestion_rate_mb: 16`, `ingestion_burst_size_mb: 32`) and per-stream limits (`10MB`/`50MB` burst) to prevent log drops under heavier volume

## Test plan
- [ ] Run `docker compose up -d loki` and verify Loki is accessible at `http://localhost:3100/ready`
- [ ] Confirm Loki is not accessible from external interfaces
- [ ] Send high-volume logs and verify no rate-limit rejections in Loki logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)