### PR TITLE
fix: add dark mode support to OAuth pages

### DIFF
--- a/services/frontend/src/routes/+layout.svelte
+++ b/services/frontend/src/routes/+layout.svelte
@@ -5,11 +5,22 @@
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 
 	export let data;
 
-	// Redirect to login if not authenticated (client-side)
+	// Initialize theme on all pages (ThemeToggle only mounts when Navigation is visible)
 	onMount(() => {
+		if (browser) {
+			const savedTheme = localStorage.getItem('theme');
+			if (savedTheme) {
+				document.documentElement.setAttribute('data-theme', savedTheme);
+			} else {
+				const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+				document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+			}
+		}
+
 		const publicRoutes = ['/login', '/register', '/oauth/authorize', '/privacy', '/terms'];
 		const isPublicRoute = publicRoutes.some((route) => $page.url.pathname.startsWith(route));
 

--- a/services/mcp-auth/mcp_auth/templates/authorization_callback.html
+++ b/services/mcp-auth/mcp_auth/templates/authorization_callback.html
@@ -67,6 +67,26 @@
             font-size: 0.9375rem;
             line-height: 1.6;
         }
+
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #1c1917;
+            }
+
+            .card {
+                background: #292524;
+                border-color: #44403c;
+                box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.2), 0 4px 6px -4px rgb(0 0 0 / 0.15);
+            }
+
+            h1 {
+                color: {{ '#f87171' if error else '#4ade80' }};
+            }
+
+            p {
+                color: #a8a29e;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Move theme initialization from `ThemeToggle` into the root layout so `data-theme` is set on all pages, including OAuth pages where `Navigation` is hidden
- Add `prefers-color-scheme: dark` styles to the mcp-auth callback template using colors matching the site's dark mode design system

## Test plan
- [ ] Visit `/oauth/authorize` with dark mode enabled and verify it uses dark theme
- [ ] Visit `/oauth/authorize` with light mode and verify it still looks correct
- [ ] Complete an OAuth flow and verify the callback page respects system dark mode preference
- [ ] Verify theme toggle still works on regular pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)