### PR TITLE
fix(mcp): apply limit parameter in list_todos backend query (task #499)

### DIFF
--- a/services/backend/app/api/todos.py
+++ b/services/backend/app/api/todos.py
@@ -842,6 +842,9 @@ async def list_todos(
     deadline_type: Literal["flexible", "preferred", "firm", "hard"] | None = Query(
         None, description="Filter by deadline type"
     ),
+    limit: int | None = Query(
+        None, ge=1, description="Maximum number of tasks to return"
+    ),
     include_subtasks: bool = Query(False),
     order_by: Literal["position", "due_date", "deadline_type"] | None = Query(
         None, description="Sort order"
@@ -853,6 +856,7 @@ async def list_todos(
     Use parent_id to get subtasks of a specific todo.
     Use include_subtasks=true to include subtasks in the response.
     Use order_by='position' to sort by manual position instead of due date.
+    Use limit to cap the number of results returned.
     """
     query = (
         select(
@@ -877,6 +881,9 @@ async def list_todos(
         deadline_type=deadline_type,
         order_by=order_by,
     )
+
+    if limit is not None:
+        query = query.limit(limit)
 
     result = await db.execute(query)
     rows = result.all()


### PR DESCRIPTION
## Summary

- The `GET /api/todos` endpoint was missing the `limit` query parameter, causing `get_tasks` MCP calls with `limit=N` to always return all tasks
- Added `limit: int | None = Query(None, ge=1)` parameter to the `list_todos` handler
- Applied `.limit(limit)` to the SQLAlchemy query when the parameter is provided

## Test plan

- [x] `test_list_todos_limit` — creates 5 tasks, requests limit=3, asserts only 3 returned
- [x] `test_list_todos_limit_larger_than_total` — creates 3 tasks, requests limit=100, asserts all 3 returned
- [x] `test_list_todos_limit_invalid` — requests limit=0, asserts 422 validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)