### PR TITLE
Add Library dropdown menu grouping Wiki and Snippets

### DIFF
--- a/services/frontend/src/lib/components/Navigation.svelte
+++ b/services/frontend/src/lib/components/Navigation.svelte
@@ -36,6 +36,8 @@
 			clearTimeout(closeTimeout);
 			closeTimeout = null;
 		}
+		tasksDropdownOpen = false;
+		libraryDropdownOpen = false;
 		newsDropdownOpen = true;
 	}
 
@@ -51,6 +53,8 @@
 			clearTimeout(closeTimeout);
 			closeTimeout = null;
 		}
+		newsDropdownOpen = false;
+		libraryDropdownOpen = false;
 		tasksDropdownOpen = true;
 	}
 
@@ -66,6 +70,8 @@
 			clearTimeout(closeTimeout);
 			closeTimeout = null;
 		}
+		newsDropdownOpen = false;
+		tasksDropdownOpen = false;
 		libraryDropdownOpen = true;
 	}
 
@@ -74,6 +80,13 @@
 			libraryDropdownOpen = false;
 			closeTimeout = null;
 		}, 200);
+	}
+
+	function handleDropdownKeydown(event: KeyboardEvent, toggle: () => void) {
+		if (event.key === ' ' || event.key === 'Enter') {
+			event.preventDefault();
+			toggle();
+		}
 	}
 
 	function toggleUserDropdown() {
@@ -215,6 +228,7 @@
 								class="nav-link nav-dropdown-trigger"
 								class:active={isTasksActive}
 								onclick={() => (tasksDropdownOpen = !tasksDropdownOpen)}
+								onkeydown={(e) => handleDropdownKeydown(e, () => (tasksDropdownOpen = !tasksDropdownOpen))}
 								role="button"
 								tabindex="0"
 								aria-expanded={tasksDropdownOpen}
@@ -275,6 +289,7 @@
 								class="nav-link nav-dropdown-trigger"
 								class:active={isNewsActive}
 								onclick={() => (newsDropdownOpen = !newsDropdownOpen)}
+								onkeydown={(e) => handleDropdownKeydown(e, () => (newsDropdownOpen = !newsDropdownOpen))}
 								role="button"
 								tabindex="0"
 								aria-expanded={newsDropdownOpen}
@@ -327,6 +342,7 @@
 								class="nav-link nav-dropdown-trigger"
 								class:active={isLibraryActive}
 								onclick={() => (libraryDropdownOpen = !libraryDropdownOpen)}
+								onkeydown={(e) => handleDropdownKeydown(e, () => (libraryDropdownOpen = !libraryDropdownOpen))}
 								role="button"
 								tabindex="0"
 								aria-expanded={libraryDropdownOpen}


### PR DESCRIPTION
## Summary
Refactored the navigation menu to group Wiki and Snippets under a new "Library" dropdown menu, improving navigation organization and consistency with other dropdown menus in the interface.

## Key Changes
- Added `libraryDropdownOpen` state variable to manage the Library dropdown visibility
- Implemented `openLibraryDropdown()` and `scheduleCloseLibraryDropdown()` functions with the same hover behavior pattern as existing dropdowns (News, Tasks)
- Created `isLibraryActive` derived state to determine if the Library dropdown should be highlighted based on current route
- Converted Wiki and Snippets from individual nav links into dropdown menu items under a new "Library" dropdown in the desktop navigation
- Moved Trash from the main navigation into the user dropdown menu for better organization
- Updated mobile menu to group Wiki and Snippets under a "Library" section label
- Moved Trash into the mobile user menu section for consistency with desktop navigation
- Updated `closeAllMenus()` and `closeDropdowns()` functions to include the new library dropdown state

## Implementation Details
- The Library dropdown follows the same interaction pattern as existing dropdowns with mouseenter/mouseleave handlers for smooth open/close behavior with a 200ms delay
- The dropdown trigger includes proper accessibility attributes (role, tabindex, aria-expanded, aria-haspopup)
- Active state styling is applied when viewing Wiki or Snippets pages
- Mobile menu maintains the same functionality while improving visual hierarchy with the new section grouping

https://claude.ai/code/session_01ArqFcZwGDf1nkHtpdutBFK