### PR TITLE
feat(wiki): expose parent_id in MCP and SDK wiki page tools

### DIFF
--- a/packages/taskmanager-sdk/taskmanager_sdk/client.py
+++ b/packages/taskmanager-sdk/taskmanager_sdk/client.py
@@ -777,6 +777,8 @@ class TaskManagerClient:
         Returns:
             ApiResponse with updated wiki page data
         """
+        if parent_id is not None and remove_parent:
+            raise ValueError("parent_id and remove_parent are mutually exclusive")
         data: dict[str, Any] = {}
         if title is not None:
             data["title"] = title

--- a/packages/taskmanager-sdk/tests/test_client.py
+++ b/packages/taskmanager-sdk/tests/test_client.py
@@ -1065,6 +1065,13 @@ class TestWikiPageParentId:
         call_args = mock_session.put.call_args
         assert call_args.kwargs["json"]["remove_parent"] is True
 
+    def test_update_wiki_page_parent_id_and_remove_parent_conflict(
+        self, client: TaskManagerClient, mock_session: Mock
+    ) -> None:
+        """Test update_wiki_page raises ValueError when both parent_id and remove_parent are set."""
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            client.update_wiki_page(page_id=3, parent_id=7, remove_parent=True)
+
     def test_update_wiki_page_without_parent_id(
         self, client: TaskManagerClient, mock_session: Mock
     ) -> None:

--- a/services/mcp-resource/mcp_resource/server.py
+++ b/services/mcp-resource/mcp_resource/server.py
@@ -1908,8 +1908,10 @@ def create_resource_server(
             revision_number, created_at, and updated_at
         """
         logger.info(
-            f"=== update_wiki_page called: page_id={page_id}, title={title}, slug={slug}, append={append}, parent_id={parent_id} ==="
+            f"=== update_wiki_page called: page_id={page_id}, title={title}, slug={slug}, append={append}, parent_id={parent_id}, remove_parent={remove_parent} ==="
         )
+        if parent_id is not None and remove_parent:
+            return json.dumps({"error": "parent_id and remove_parent are mutually exclusive"})
         try:
             api_client = get_api_client()
             response = api_client.update_wiki_page(

--- a/services/mcp-resource/tests/test_mcp_tools.py
+++ b/services/mcp-resource/tests/test_mcp_tools.py
@@ -2146,6 +2146,23 @@ class TestWikiTools:
             )
 
     @pytest.mark.asyncio
+    async def test_update_wiki_page_parent_id_and_remove_parent_conflict(
+        self, mock_api_client: MagicMock
+    ) -> None:
+        """Test that passing both parent_id and remove_parent returns an error."""
+        import json
+
+        with patch("mcp_resource.server.get_api_client", return_value=mock_api_client):
+            tools = self._create_server(mock_api_client)
+            result = await tools["update_wiki_page"].fn(
+                page_id=3, parent_id=7, remove_parent=True
+            )
+            parsed = json.loads(result)
+            assert "error" in parsed
+            assert "mutually exclusive" in parsed["error"]
+            mock_api_client.update_wiki_page.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_batch_link_wiki_page_to_tasks_success(self, mock_api_client: MagicMock) -> None:
         """Test batch linking tasks to a wiki page."""
         import json


### PR DESCRIPTION
## Summary
- Adds `parent_id` parameter to `create_wiki_page` in both the SDK client and MCP resource server, enabling hierarchical page creation
- Adds `parent_id` and `remove_parent` parameters to `update_wiki_page` in both layers, allowing pages to be moved or promoted to root
- The backend already had full support (model, schemas, validation with max depth of 3 and circular reference checks) — this just threads the parameter through the SDK and MCP tools

## Test plan
- [x] 5 new SDK unit tests (`TestWikiPageParentId`) covering create/update with and without parent_id, and remove_parent
- [x] 3 new MCP tool tests covering create with parent_id, update with parent_id, and remove_parent
- [x] 1 existing MCP test assertion updated for new call signature
- [ ] Manual verification: create nested wiki pages via MCP tool and confirm hierarchy renders in frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)