### PR TITLE
feat(mcp-relay): add cursor-based pagination to read_messages (task #451)

### DIFF
--- a/services/mcp-relay/mcp_relay/debug.py
+++ b/services/mcp-relay/mcp_relay/debug.py
@@ -69,7 +69,7 @@ async def messages_handler(request: Request) -> JSONResponse:
         limit = 100
 
     try:
-        messages = store.get(channel, since=since, limit=limit)
+        messages, _ = store.get(channel, since=since, limit=limit)
     except ValueError as e:
         return JSONResponse({"error": str(e)}, status_code=400)
 

--- a/services/mcp-relay/tests/test_debug.py
+++ b/services/mcp-relay/tests/test_debug.py
@@ -145,7 +145,7 @@ class TestDebugMessagesAPI:
         resp = client.get("/api/channels/debug/messages?limit=3")
         data = resp.json()
         assert data["count"] == 3
-        # Should return the last 3 messages
+        # Should return the most recent 3 messages (no-cursor preserves original behavior)
         assert data["messages"][0]["content"] == "msg-7"
         assert data["messages"][2]["content"] == "msg-9"
 
@@ -194,7 +194,7 @@ class TestDebugSendAPI:
         assert "timestamp" in data
 
         # Verify it's in the store
-        messages = store.get("test")
+        messages, _ = store.get("test")
         assert len(messages) == 1
         assert messages[0].content == "hello from debug"
 
@@ -272,7 +272,8 @@ class TestDebugClearAPI:
         assert data["cleared"] is True
 
         # Verify the store is empty
-        assert store.get("test") == []
+        messages, _ = store.get("test")
+        assert messages == []
 
     def test_clear_nonexistent(self, client: TestClient) -> None:
         resp = client.post("/api/channels/nonexistent/clear")


### PR DESCRIPTION
## Summary
- Add `before` and `after` cursor parameters to `MessageStore.get()`
- Update `read_messages` MCP tool to support cursor-based pagination
- Include `has_more` flag in response for pagination awareness
- Add comprehensive tests for cursor pagination

Closes task #451

## Test plan
- [x] Unit tests for `after` cursor filtering
- [x] Unit tests for `before` cursor filtering
- [x] Tests for `has_more` flag accuracy
- [x] Tests for invalid cursor IDs
- [x] Tests combining cursors with `since` and `limit`
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)