### PR TITLE
fix(backend): use deque.popleft() in circular dependency check (task #471)

### DIFF
--- a/services/backend/app/api/todos.py
+++ b/services/backend/app/api/todos.py
@@ -1,5 +1,6 @@
 """Todo API routes."""
 
+from collections import deque
 from datetime import UTC, date, datetime
 from typing import Literal
 
@@ -1710,10 +1711,10 @@ async def _check_circular_dependency(
 
     # BFS to find if dependent_id is reachable from dependency_id
     visited: set[int] = set()
-    queue = [dependency_id]
+    queue: deque[int] = deque([dependency_id])
 
     while queue:
-        current_id = queue.pop(0)
+        current_id = queue.popleft()
         if current_id == dependent_id:
             return True  # Found a cycle
 


### PR DESCRIPTION
## Summary
- Replace O(n) `list.pop(0)` with O(1) `deque.popleft()` in `_check_circular_dependency` BFS
- Move `from collections import deque` to module top-level import

## Task
https://todo.brooksmcmillin.com/task/471

Generated with [Claude Code](https://claude.com/claude-code)