### PR TITLE
fix(mcp-resource-framework): move Lakera project ID to env var (task #469)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,3 +109,6 @@ LAKERA_GUARD_ENABLED=false
 
 # Lakera Guard API endpoint (optional, defaults to https://api.lakera.ai/v2/guard)
 # LAKERA_GUARD_API_URL=https://api.lakera.ai/v2/guard
+
+# Lakera Guard project ID (optional, defaults to built-in project)
+# LAKERA_GUARD_PROJECT_ID=your_project_id_here

--- a/packages/mcp-resource-framework/mcp_resource_framework/security/lakera_guard.py
+++ b/packages/mcp-resource-framework/mcp_resource_framework/security/lakera_guard.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 LAKERA_API_URL = os.environ.get("LAKERA_GUARD_API_URL", "https://api.lakera.ai/v2/guard")
 LAKERA_API_KEY = os.environ.get("LAKERA_GUARD_API_KEY", "")
 LAKERA_GUARD_ENABLED = os.environ.get("LAKERA_GUARD_ENABLED", "false").lower() == "true"
+LAKERA_PROJECT_ID = os.environ.get("LAKERA_GUARD_PROJECT_ID", "project-9146177048")
 
 # Type variables for generic decorator
 P = ParamSpec("P")
@@ -58,7 +59,7 @@ async def screen_content(text: str, role: str = "user") -> dict[str, Any]:
             json={
                 "messages": [{"role": role, "content": text}],
                 "breakdown": True,
-                "project_id": os.environ.get("LAKERA_GUARD_PROJECT_ID", "project-9146177048"),
+                "project_id": LAKERA_PROJECT_ID,
             },
             headers={
                 "Authorization": f"Bearer {LAKERA_API_KEY}",


### PR DESCRIPTION
## Summary
- Move hardcoded Lakera Guard project ID to `LAKERA_GUARD_PROJECT_ID` environment variable
- Keep current value as default for backwards compatibility

## Task
https://todo.brooksmcmillin.com/task/469

Generated with [Claude Code](https://claude.com/claude-code)