### PR TITLE
fix(scripts): refresh MCP token every 30 min and remove early-exit skip

### DIFF
--- a/scripts/install-cron.sh
+++ b/scripts/install-cron.sh
@@ -53,8 +53,8 @@ touch "$LOG_FILE"
 chmod 600 "$LOG_FILE"
 
 # Append to existing crontab
-CRON_LINE="*/45 * * * * set -a; . \"$ENV_FILE\"; set +a; \"$REFRESH_SCRIPT\" >> \"$LOG_FILE\" 2>&1"
-(crontab -l 2>/dev/null; echo ""; echo "# MCP OAuth token refresh (every 45 min)"; echo "$CRON_LINE") | crontab -
+CRON_LINE="*/30 * * * * set -a; . \"$ENV_FILE\"; set +a; \"$REFRESH_SCRIPT\" >> \"$LOG_FILE\" 2>&1"
+(crontab -l 2>/dev/null; echo ""; echo "# MCP OAuth token refresh (every 30 min)"; echo "$CRON_LINE") | crontab -
 
 echo "Cron job installed:"
 echo "  $CRON_LINE"

--- a/scripts/mcp-refresh-token.sh
+++ b/scripts/mcp-refresh-token.sh
@@ -15,8 +15,8 @@
 # Usage:
 #   NTFY_TOKEN=tk_... ./scripts/mcp-refresh-token.sh
 #
-# Cron example (every 45 minutes):
-#   */45 * * * * set -a; . /path/to/.env; set +a; /path/to/scripts/mcp-refresh-token.sh >> ~/.local/log/mcp-refresh.log 2>&1
+# Cron example (every 30 minutes):
+#   */30 * * * * set -a; . /path/to/.env; set +a; /path/to/scripts/mcp-refresh-token.sh >> ~/.local/log/mcp-refresh.log 2>&1
 #
 # Environment variables:
 #   NTFY_TOKEN  - (required) ntfy bearer token for push notifications
@@ -104,17 +104,6 @@ if [[ -z "$REFRESH_TOKEN" || "$REFRESH_TOKEN" == "null" ]]; then
     echo "$(date -Iseconds) Error: No refresh_token found. Run mcp-device-auth.sh first." >&2
     send_alert "MCP Token: No Refresh Token [$THIS_HOST]" "No refresh_token in credentials on $THIS_HOST. Run mcp-device-auth.sh to re-authenticate."
     exit 1
-fi
-
-# --- Check if access token is still valid (skip refresh if not expiring soon) ---
-EXPIRES_AT=$(jq -r --arg key "$PRIMARY_KEY" '.mcpOAuth[$key].expiresAt // 0' "$CREDENTIALS_FILE")
-NOW_MS=$(( $(date +%s) * 1000 ))
-# Refresh if token expires within 10 minutes (600000ms)
-BUFFER_MS=600000
-if [[ "$EXPIRES_AT" =~ ^[0-9]+$ ]] && (( EXPIRES_AT - NOW_MS > BUFFER_MS )); then
-    REMAINING_MIN=$(( (EXPIRES_AT - NOW_MS) / 60000 ))
-    echo "$(date -Iseconds) Token still valid for ~${REMAINING_MIN} minutes, skipping refresh. (${#MCP_KEYS[@]} server(s) covered)"
-    exit 0
 fi
 
 echo "$(date -Iseconds) Refreshing access token for ${#MCP_KEYS[@]} server(s)..."


### PR DESCRIPTION
## Summary
- Change MCP token refresh cron interval from 45 minutes to 30 minutes
- Remove the early-exit check that skipped refresh when the token had >10 minutes remaining — this could cause stale tokens if expiry tracking drifted
- Always refresh on each cron run for reliability

## Test plan
- [ ] Verify cron installs with 30-minute interval via `install-cron.sh`
- [ ] Confirm `mcp-refresh-token.sh` always performs a refresh without skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)