### PR TITLE
Replace SHA-256 key derivation with HKDF for token encryption

### DIFF
--- a/services/backend/app/services/token_encryption.py
+++ b/services/backend/app/services/token_encryption.py
@@ -1,25 +1,49 @@
 """Token encryption service for securing OAuth tokens at rest.
 
 Uses Fernet symmetric encryption with the application's secret key.
+Key derivation uses HKDF (HMAC-based Key Derivation Function) with SHA-256
+for cryptographically sound key material generation.
+
+Note: Changing the key derivation from SHA-256 to HKDF is a breaking change.
+Existing encrypted tokens stored in the database will be undecryptable with
+the new key. Users with linked GitHub accounts will need to re-authenticate
+via GitHub OAuth to generate a new token stored with the new key derivation.
 """
 
 import base64
-import hashlib
 
 from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from app.config import settings
 
+# Static salt for HKDF — ensures deterministic key derivation from SECRET_KEY.
+# This is intentionally a fixed value; randomness comes from the SECRET_KEY itself.
+_HKDF_SALT = b"taskmanager-token-encryption-salt-v1"
+
+# Info context string scopes this key exclusively to GitHub OAuth token encryption.
+_HKDF_INFO = b"github-oauth-token-encryption"
+
 
 def _get_encryption_key() -> bytes:
-    """Derive a Fernet-compatible key from the application secret.
+    """Derive a Fernet-compatible key from the application secret using HKDF.
 
-    Fernet requires a 32-byte base64-encoded key. We derive this from
-    the application's SECRET_KEY using SHA-256.
+    Uses HKDF (HMAC-based Key Derivation Function) with SHA-256 to derive a
+    cryptographically sound 32-byte key from the application's SECRET_KEY.
+    HKDF is a proper KDF that provides better security properties than a raw
+    SHA-256 hash.
+
+    Returns:
+        A URL-safe base64-encoded 32-byte key suitable for use with Fernet.
     """
-    # Hash the secret key to get exactly 32 bytes
-    key_bytes = hashlib.sha256(settings.secret_key.encode()).digest()
-    # Base64 encode for Fernet compatibility
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=_HKDF_SALT,
+        info=_HKDF_INFO,
+    )
+    key_bytes = hkdf.derive(settings.secret_key.encode())
     return base64.urlsafe_b64encode(key_bytes)
 
 

--- a/services/backend/tests/test_github_oauth.py
+++ b/services/backend/tests/test_github_oauth.py
@@ -549,6 +549,73 @@ def test_token_decryption_invalid_token():
     assert decrypt_token("gAAAAA_not_valid_fernet") is None
 
 
+def test_hkdf_key_derivation_produces_valid_fernet_key():
+    """Test that HKDF key derivation produces a valid Fernet key."""
+    from cryptography.fernet import Fernet
+
+    from app.services.token_encryption import _get_encryption_key
+
+    key = _get_encryption_key()
+
+    # Must be bytes
+    assert isinstance(key, bytes)
+
+    # Must be a valid Fernet key (32 bytes base64url-encoded = 44 chars with padding)
+    assert len(key) == 44
+
+    # Must be usable with Fernet without raising an exception
+    fernet = Fernet(key)
+    assert fernet is not None
+
+
+def test_hkdf_key_derivation_is_deterministic():
+    """Test that HKDF key derivation is deterministic for the same secret."""
+    from app.services.token_encryption import _get_encryption_key
+
+    key1 = _get_encryption_key()
+    key2 = _get_encryption_key()
+
+    assert key1 == key2
+
+
+def test_hkdf_different_secrets_produce_different_keys():
+    """Test that different SECRET_KEY values produce different derived keys."""
+    import unittest.mock
+
+    from app.services.token_encryption import _get_encryption_key
+
+    with unittest.mock.patch("app.services.token_encryption.settings") as mock_settings:
+        mock_settings.secret_key = "secret-one"  # pragma: allowlist secret
+        key1 = _get_encryption_key()
+
+    with unittest.mock.patch("app.services.token_encryption.settings") as mock_settings:
+        mock_settings.secret_key = "secret-two"  # pragma: allowlist secret
+        key2 = _get_encryption_key()
+
+    assert key1 != key2
+
+
+def test_hkdf_token_not_decryptable_with_different_secret():
+    """Test that tokens encrypted with one secret cannot be decrypted with another."""
+    import unittest.mock
+
+    from app.services.token_encryption import decrypt_token, encrypt_token
+
+    original_token = "gho_sensitive_token_abc123"
+
+    # Encrypt with one secret
+    with unittest.mock.patch("app.services.token_encryption.settings") as mock_settings:
+        mock_settings.secret_key = "first-secret-key"  # pragma: allowlist secret
+        encrypted = encrypt_token(original_token)
+
+    # Attempt to decrypt with a different secret
+    with unittest.mock.patch("app.services.token_encryption.settings") as mock_settings:
+        mock_settings.secret_key = "second-secret-key"  # pragma: allowlist secret
+        result = decrypt_token(encrypted)
+
+    assert result is None
+
+
 # =============================================================================
 # Return-to Validation Tests
 # =============================================================================


### PR DESCRIPTION
## Summary
- Replaces single SHA-256 hash key derivation with HKDF (HMAC-based Key Derivation Function)
- Uses proper salt and info context string for cryptographic key derivation
- Note: This changes the derived encryption key. Existing GitHub OAuth tokens stored with the old key will need to be re-authenticated.

Fixes https://todo.brooksmcmillin.com/task/474

## Test plan
- [x] Unit tests for HKDF key derivation
- [x] Encryption/decryption round-trip tests
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)