### PR TITLE
Fix X-Forwarded-For IP spoofing in rate limiter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
             .*/oauth_provider.*|
             .*/auth_server\.py|
             .*/taskmanager_sdk/.*|
-            .*/dependencies\.py
+            services/backend/app/dependencies\.py
           )$
 
   # =============================================================================

--- a/services/backend/app/config.py
+++ b/services/backend/app/config.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from pathlib import Path
 from urllib.parse import urlparse
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Project root is three levels up from this file
@@ -59,7 +59,11 @@ class Settings(BaseSettings):
     # Set to 0 if running without a reverse proxy (use request.client.host directly).
     # Set to 1 (default) for a single reverse proxy (e.g. nginx or a load balancer).
     # Set to N for N chained trusted proxies.
-    trusted_proxy_count: int = 1
+    #
+    # IMPORTANT: configure your upstream proxy to OVERWRITE (not append to) the
+    # X-Forwarded-For header so that clients cannot inject spoofed IPs into the
+    # leftmost position of the chain.
+    trusted_proxy_count: int = Field(default=1, ge=0)
 
     # OAuth
     access_token_expiry: int = 86400  # 24 hours in seconds

--- a/services/backend/app/dependencies.py
+++ b/services/backend/app/dependencies.py
@@ -1,5 +1,6 @@
 """FastAPI dependency injection."""
 
+import ipaddress
 import secrets
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
@@ -257,6 +258,15 @@ async def _validate_api_key(
     raise errors.invalid_token()
 
 
+def _parse_ip(value: str) -> str | None:
+    """Return value if it is a valid IPv4/IPv6 address string, else None."""
+    try:
+        ipaddress.ip_address(value)
+        return value
+    except ValueError:
+        return None
+
+
 def _get_client_ip(request: Request) -> str | None:
     """Extract client IP from request, validating X-Forwarded-For.
 
@@ -269,10 +279,10 @@ def _get_client_ip(request: Request) -> str | None:
       - The rightmost entry (10.0.0.1) was added by our single trusted proxy.
       - The entry just to the left of it (1.2.3.4) is the real client IP.
 
-    If the X-Forwarded-For chain is shorter than expected (e.g. an attacker
-    sent the header but the request did not pass through all expected proxies)
-    we fall back to request.client.host, which is the TCP-layer address that
-    cannot be spoofed by the client.
+    If the X-Forwarded-For chain is shorter than expected, or if the selected
+    entry is not a valid IP address (e.g. a hostname or "unknown"), we fall back
+    to request.client.host, which is the TCP-layer address that cannot be
+    spoofed by the client.
     """
     trusted_proxy_count = settings.trusted_proxy_count
 
@@ -290,8 +300,12 @@ def _get_client_ip(request: Request) -> str | None:
         # The real client IP sits one position before those proxy entries.
         # Required minimum list length: trusted_proxy_count + 1 (the actual client).
         if len(ips) > trusted_proxy_count:
-            return ips[-(trusted_proxy_count + 1)]
-        # The header chain is shorter than expected — fall through to direct host.
+            candidate = ips[-(trusted_proxy_count + 1)]
+            parsed = _parse_ip(candidate)
+            if parsed is not None:
+                return parsed
+        # The header chain is shorter than expected or contains non-IP values —
+        # fall through to the direct host address.
 
     # Fall back to the direct TCP-layer peer address.
     if request.client:

--- a/services/backend/tests/test_dependencies.py
+++ b/services/backend/tests/test_dependencies.py
@@ -13,6 +13,7 @@ from app.core.errors import ApiError
 from app.core.security import generate_api_key, generate_token, hash_password
 from app.dependencies import (
     _get_client_ip,
+    _parse_ip,
     get_admin_user,
     get_current_user,
     get_current_user_flexible,
@@ -974,3 +975,51 @@ def test_get_client_ip_strips_whitespace_around_ips():
         mock_settings.trusted_proxy_count = 1
         ip = _get_client_ip(request)
     assert ip == "9.9.9.9"
+
+
+def test_get_client_ip_non_ip_value_falls_back():
+    """Non-IP string in the header (e.g. hostname or 'unknown') falls back."""
+    request = _make_request(
+        headers=[(b"x-forwarded-for", b"unknown, 10.0.0.1")],
+        client_host="10.0.0.1",
+    )
+    with patch("app.dependencies.settings") as mock_settings:
+        mock_settings.trusted_proxy_count = 1
+        ip = _get_client_ip(request)
+    # "unknown" is not a valid IP — should fall back to client.host.
+    assert ip == "10.0.0.1"
+
+
+def test_get_client_ip_ipv6_address():
+    """IPv6 addresses in X-Forwarded-For are handled correctly."""
+    request = _make_request(
+        headers=[(b"x-forwarded-for", b"2001:db8::1, 10.0.0.1")],
+        client_host="10.0.0.1",
+    )
+    with patch("app.dependencies.settings") as mock_settings:
+        mock_settings.trusted_proxy_count = 1
+        ip = _get_client_ip(request)
+    assert ip == "2001:db8::1"
+
+
+# Tests for the _parse_ip helper directly.
+
+
+def test_parse_ip_valid_ipv4():
+    """Valid IPv4 address is returned as-is."""
+    assert _parse_ip("1.2.3.4") == "1.2.3.4"
+
+
+def test_parse_ip_valid_ipv6():
+    """Valid IPv6 address is returned as-is."""
+    assert _parse_ip("::1") == "::1"
+
+
+def test_parse_ip_hostname_returns_none():
+    """Hostnames are rejected and None is returned."""
+    assert _parse_ip("example.com") is None
+
+
+def test_parse_ip_unknown_returns_none():
+    """'unknown' string is rejected and None is returned."""
+    assert _parse_ip("unknown") is None


### PR DESCRIPTION
## Summary
- Adds `TRUSTED_PROXY_COUNT` setting to configure how many reverse proxies are trusted (default: 1)
- Fixes `_get_client_ip` to extract the correct client IP from X-Forwarded-For based on trusted proxy count, taking `ips[-(trusted_proxy_count + 1)]` from the right of the chain
- Falls back to `request.client.host` when the header chain is shorter than expected (spoofing attempt or no proxies present)
- Excludes `app/dependencies.py` from the `no-hardcoded-tokens` pygrep pre-commit hook (pre-existing false positives on `access_token`/`token` variable names)

Fixes https://todo.brooksmcmillin.com/task/468

## Test plan
- [x] Unit tests for `_get_client_ip` with various X-Forwarded-For configurations (10 tests)
- [x] No X-Forwarded-For header → uses `request.client.host`
- [x] Single proxy (default `TRUSTED_PROXY_COUNT=1`) with valid X-Forwarded-For
- [x] Multiple proxies with correct trusted count (e.g. 2 proxies)
- [x] Spoofed X-Forwarded-For with too few entries → falls back to `request.client.host`
- [x] Header with exactly `trusted_proxy_count` entries (no room for client IP) → falls back
- [x] Empty header and whitespace-only header → both fall back
- [x] `trusted_proxy_count=0` → always uses direct TCP address, ignores header
- [x] No client and no header → returns `None`
- [x] Whitespace stripping around IPs works correctly
- [x] Existing rate limiter tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)