### PR TITLE
feat(security): make Lakera Guard fail-open/fail-closed configurable (task #470)

### DIFF
--- a/packages/mcp-resource-framework/mcp_resource_framework/security/lakera_guard.py
+++ b/packages/mcp-resource-framework/mcp_resource_framework/security/lakera_guard.py
@@ -22,6 +22,8 @@ LAKERA_API_URL = os.environ.get("LAKERA_GUARD_API_URL", "https://api.lakera.ai/v
 LAKERA_API_KEY = os.environ.get("LAKERA_GUARD_API_KEY", "")
 LAKERA_GUARD_ENABLED = os.environ.get("LAKERA_GUARD_ENABLED", "false").lower() == "true"
 LAKERA_PROJECT_ID = os.environ.get("LAKERA_GUARD_PROJECT_ID", "project-9146177048")
+# When true, API errors allow the request through (fail-open). Default is fail-closed.
+LAKERA_FAIL_OPEN = os.environ.get("LAKERA_FAIL_OPEN", "false").lower() in ("true", "1", "yes")
 
 # Type variables for generic decorator
 P = ParamSpec("P")
@@ -214,9 +216,20 @@ async def _screen_and_handle(
             logger.debug(f"Lakera Guard: {context} passed security screening")
 
     except httpx.HTTPError as e:
-        logger.error(f"Lakera Guard API error while screening {context}: {e}")
-        # On API errors, we log but don't block (fail-open for availability)
-        # Change this behavior based on your security requirements
+        if LAKERA_FAIL_OPEN:
+            logger.warning(
+                f"Lakera Guard API error while screening {context}: {e}. "
+                "LAKERA_FAIL_OPEN=true, allowing request through."
+            )
+        else:
+            logger.error(
+                f"Lakera Guard API error while screening {context}: {e}. "
+                "LAKERA_FAIL_OPEN=false (fail-closed), rejecting request."
+            )
+            raise LakeraGuardError(
+                f"Lakera Guard API unavailable while screening {context}; "
+                "request blocked for safety."
+            ) from e
 
 
 def guard_tool(

--- a/packages/mcp-resource-framework/tests/test_lakera_guard.py
+++ b/packages/mcp-resource-framework/tests/test_lakera_guard.py
@@ -1,0 +1,227 @@
+"""Tests for Lakera Guard fail-open/fail-closed configuration."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+import mcp_resource_framework.security.lakera_guard as lakera_module
+from mcp_resource_framework.security.lakera_guard import (
+    LakeraGuardError,
+    _screen_and_handle,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CLEAN_RESPONSE: dict = {"results": [{"flagged": False, "categories": {}}]}
+
+_FLAGGED_RESPONSE: dict = {
+    "results": [
+        {
+            "flagged": True,
+            "categories": {"prompt_injection": True},
+        }
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests for _screen_and_handle – fail-open / fail-closed on HTTPError
+# ---------------------------------------------------------------------------
+
+
+class TestFailOpenConfig:
+    """LAKERA_FAIL_OPEN controls what happens when the API raises HTTPError."""
+
+    @pytest.mark.asyncio
+    async def test_fail_open_true_allows_request_on_http_error(self) -> None:
+        """When LAKERA_FAIL_OPEN=true, HTTPError should NOT raise; request passes."""
+        http_error = httpx.HTTPStatusError(
+            "503 Service Unavailable",
+            request=httpx.Request("POST", "https://api.lakera.ai/v2/guard"),
+            response=httpx.Response(503),
+        )
+        with (
+            patch.object(lakera_module, "LAKERA_FAIL_OPEN", True),
+            patch(
+                "mcp_resource_framework.security.lakera_guard.screen_content",
+                new_callable=AsyncMock,
+                side_effect=http_error,
+            ),
+        ):
+            # Should not raise
+            await _screen_and_handle(
+                content="some user input",
+                role="user",
+                context="test context",
+                block_on_detection=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_false_rejects_request_on_http_error(self) -> None:
+        """When LAKERA_FAIL_OPEN=false (default), HTTPError should raise LakeraGuardError."""
+        http_error = httpx.HTTPStatusError(
+            "503 Service Unavailable",
+            request=httpx.Request("POST", "https://api.lakera.ai/v2/guard"),
+            response=httpx.Response(503),
+        )
+        with (
+            patch.object(lakera_module, "LAKERA_FAIL_OPEN", False),
+            patch(
+                "mcp_resource_framework.security.lakera_guard.screen_content",
+                new_callable=AsyncMock,
+                side_effect=http_error,
+            ),
+            pytest.raises(LakeraGuardError, match="Lakera Guard API unavailable"),
+        ):
+            await _screen_and_handle(
+                content="some user input",
+                role="user",
+                context="test context",
+                block_on_detection=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_default_behavior_is_fail_closed(self) -> None:
+        """The module-level LAKERA_FAIL_OPEN default must be False (fail-closed)."""
+        # Read the actual constant from the module (not patched)
+        assert lakera_module.LAKERA_FAIL_OPEN is False, (
+            "LAKERA_FAIL_OPEN must default to False for production safety"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fail_open_logs_warning_not_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """In fail-open mode, the log message should be WARNING level."""
+        http_error = httpx.ConnectError("Connection refused")
+        log_name = "mcp_resource_framework.security.lakera_guard"
+        with (
+            patch.object(lakera_module, "LAKERA_FAIL_OPEN", True),
+            patch(
+                "mcp_resource_framework.security.lakera_guard.screen_content",
+                new_callable=AsyncMock,
+                side_effect=http_error,
+            ),
+            caplog.at_level(logging.WARNING, logger=log_name),
+        ):
+            await _screen_and_handle(
+                content="test content",
+                role="user",
+                context="unit test",
+                block_on_detection=True,
+            )
+
+        assert any("LAKERA_FAIL_OPEN=true" in record.message for record in caplog.records)
+        # Must be WARNING, not ERROR
+        warning_records = [r for r in caplog.records if "LAKERA_FAIL_OPEN=true" in r.message]
+        assert all(r.levelname == "WARNING" for r in warning_records)
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_logs_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """In fail-closed mode, the log message should be ERROR level."""
+        http_error = httpx.ConnectError("Connection refused")
+        log_name = "mcp_resource_framework.security.lakera_guard"
+        with (
+            patch.object(lakera_module, "LAKERA_FAIL_OPEN", False),
+            patch(
+                "mcp_resource_framework.security.lakera_guard.screen_content",
+                new_callable=AsyncMock,
+                side_effect=http_error,
+            ),
+            caplog.at_level(logging.ERROR, logger=log_name),
+            pytest.raises(LakeraGuardError),
+        ):
+            await _screen_and_handle(
+                content="test content",
+                role="user",
+                context="unit test",
+                block_on_detection=True,
+            )
+
+        assert any("LAKERA_FAIL_OPEN=false" in record.message for record in caplog.records)
+        error_records = [r for r in caplog.records if "LAKERA_FAIL_OPEN=false" in r.message]
+        assert all(r.levelname == "ERROR" for r in error_records)
+
+    @pytest.mark.asyncio
+    async def test_fail_open_network_error_allows_request(self) -> None:
+        """Fail-open applies to network errors (ConnectError) as well as HTTP errors."""
+        with (
+            patch.object(lakera_module, "LAKERA_FAIL_OPEN", True),
+            patch(
+                "mcp_resource_framework.security.lakera_guard.screen_content",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectError("timeout"),
+            ),
+        ):
+            # Should not raise
+            await _screen_and_handle(
+                content="some content",
+                role="user",
+                context="network test",
+                block_on_detection=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_network_error_rejects_request(self) -> None:
+        """Fail-closed applies to network errors (ConnectError) as well as HTTP errors."""
+        with (
+            patch.object(lakera_module, "LAKERA_FAIL_OPEN", False),
+            patch(
+                "mcp_resource_framework.security.lakera_guard.screen_content",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectError("timeout"),
+            ),
+            pytest.raises(LakeraGuardError),
+        ):
+            await _screen_and_handle(
+                content="some content",
+                role="user",
+                context="network test",
+                block_on_detection=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_clean_content_passes_regardless_of_fail_mode(self) -> None:
+        """When the API succeeds and content is clean, both modes allow the request."""
+        for fail_open in (True, False):
+            with (
+                patch.object(lakera_module, "LAKERA_FAIL_OPEN", fail_open),
+                patch(
+                    "mcp_resource_framework.security.lakera_guard.screen_content",
+                    new_callable=AsyncMock,
+                    return_value=_CLEAN_RESPONSE,
+                ),
+            ):
+                # Should not raise in either mode
+                await _screen_and_handle(
+                    content="safe content",
+                    role="user",
+                    context="clean content test",
+                    block_on_detection=True,
+                )
+
+    @pytest.mark.asyncio
+    async def test_flagged_content_always_blocked_when_block_on_detection_true(
+        self,
+    ) -> None:
+        """Flagged content is blocked regardless of LAKERA_FAIL_OPEN when block_on_detection."""
+        for fail_open in (True, False):
+            with (
+                patch.object(lakera_module, "LAKERA_FAIL_OPEN", fail_open),
+                patch(
+                    "mcp_resource_framework.security.lakera_guard.screen_content",
+                    new_callable=AsyncMock,
+                    return_value=_FLAGGED_RESPONSE,
+                ),
+                pytest.raises(LakeraGuardError, match="prompt_injection"),
+            ):
+                await _screen_and_handle(
+                    content="inject this",
+                    role="user",
+                    context="flagged content test",
+                    block_on_detection=True,
+                )


### PR DESCRIPTION
## Summary
- Add `LAKERA_FAIL_OPEN` env var to control behavior when Lakera Guard API errors
- Default to fail-closed (reject requests) for production safety
- When set to `true`, falls back to current behavior (log and allow)

## Task
https://todo.brooksmcmillin.com/task/470

## Test plan
- [ ] Tests pass for fail-open mode
- [ ] Tests pass for fail-closed mode (default)
- [ ] Ruff lint and format checks pass
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)