### PR TITLE
fix: patch SvelteKit vuln, fix flaky test, fix husky audit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -148,7 +148,11 @@ fi
 # 5. Quick dependency check if package.json changed
 if echo "$STAGED_FILES" | grep -q "package.*json"; then
     echo "5. Checking dependencies..."
-    if ! npm audit --production --audit-level=critical 2>&1 | grep -q "found 0 vulnerabilities"; then
+    # Source nvm if npm is not on PATH (npm installed via nvm isn't available in /bin/sh)
+    if ! command -v npm >/dev/null 2>&1 && [ -s "$HOME/.nvm/nvm.sh" ]; then
+        . "$HOME/.nvm/nvm.sh"
+    fi
+    if ! npm audit --omit=dev --audit-level=critical --prefix services/frontend 2>&1 | grep -q "found 0 vulnerabilities"; then
         printf '%b\n' "${RED}  ❌ Critical vulnerabilities in dependencies!${NC}"
         echo "     Run 'npm audit' for details"
         FAILED=1

--- a/services/frontend/package-lock.json
+++ b/services/frontend/package-lock.json
@@ -1328,12 +1328,11 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.53.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.53.2.tgz",
-			"integrity": "sha512-M+MqAvFve12T1HWws/2npP/s3hFtyjw3GB/OXW/8a1jZBk48qnvPJrtgE+VOMc3RnjUMxc4mv/vQ73nvj2uNMg==",
+			"version": "2.53.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.53.4.tgz",
+			"integrity": "sha512-iAIPEahFgDJJyvz8g0jP08KvqnM6JvdW8YfsygZ+pMeMvyM2zssWMltcsotETvjSZ82G3VlitgDtBIvpQSZrTA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1376,7 +1375,6 @@
 			"integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"deepmerge": "^4.3.1",
@@ -1439,7 +1437,6 @@
 			"integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -1462,7 +1459,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1940,7 +1936,6 @@
 			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -2003,7 +1998,6 @@
 			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -2062,7 +2056,6 @@
 			"integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.0.2",
@@ -2128,7 +2121,6 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.5.tgz",
 			"integrity": "sha512-YkqERnF05g8KLdDZwZrF8/i1eSbj6Eoat8Jjr2IfruZz9StLuBqo8sfCSzjosNKd+ZrQ8DkKZDjpO5y3ht1Pow==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2233,7 +2225,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2255,7 +2246,6 @@
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",

--- a/services/mcp-resource/tests/test_lakera_guard.py
+++ b/services/mcp-resource/tests/test_lakera_guard.py
@@ -392,6 +392,7 @@ class TestAPIErrorHandling:
 
         with (
             patch("mcp_resource_framework.security.lakera_guard.LAKERA_GUARD_ENABLED", True),
+            patch("mcp_resource_framework.security.lakera_guard.LAKERA_FAIL_OPEN", True),
             patch("mcp_resource_framework.security.lakera_guard.screen_content", failing_screen),
         ):
             # Should not raise, execution continues (fail-open for availability)


### PR DESCRIPTION
## Summary

- **Security**: Upgrade `@sveltejs/kit` 2.53.2 → 2.53.4 to fix [GHSA-fpg4-jhqr-589c](https://github.com/advisories/GHSA-fpg4-jhqr-589c) (deserialization expansion DoS in experimental form remote function)
- **Flaky test**: Fix `test_api_error_fails_open` by patching `LAKERA_FAIL_OPEN` to `True` — the test expected fail-open behavior but wasn't setting the flag, which defaults to `False` (fail-closed)
- **Husky hook**: Fix pre-commit npm audit false positives — `npm` wasn't on PATH in `/bin/sh` (nvm), and audit ran from repo root instead of `services/frontend/`

## Test plan

- [x] `npm audit` in `services/frontend/` reports 0 vulnerabilities
- [x] `test_lakera_guard.py::TestAPIErrorHandling` passes (211/211 tests pass)
- [x] `svelte-check` passes with 0 errors
- [x] Husky pre-commit hook passes all security checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)