### PR TITLE
refactor: extract batch_create_todos into phase helpers

### DIFF
--- a/services/backend/app/api/todos.py
+++ b/services/backend/app/api/todos.py
@@ -1090,8 +1090,9 @@ async def _validate_batch_wiki_page(
     )
 
 
-def _validate_batch_depends_on(todos: list[TodoCreate], batch_size: int) -> None:
+def _validate_batch_depends_on(todos: list[TodoCreate]) -> None:
     """Phase 0b: Validate depends_on indices for bounds, self-refs, and cycles."""
+    batch_size = len(todos)
     for i, item in enumerate(todos):
         if item.depends_on:
             for dep_idx in item.depends_on:
@@ -1332,7 +1333,7 @@ async def batch_create_todos(
     # Validation
     if request.wiki_page_id is not None:
         await _validate_batch_wiki_page(db, request.wiki_page_id, user.id)
-    _validate_batch_depends_on(request.todos, len(request.todos))
+    _validate_batch_depends_on(request.todos)
     skipped_indices = await _detect_batch_duplicates(
         db, request.todos, user.id, request.skip_duplicates
     )

--- a/services/backend/tests/test_event_bus.py
+++ b/services/backend/tests/test_event_bus.py
@@ -27,10 +27,15 @@ class TestEventBusDispatch:
         user_id: int = 10,
         tab: str = "abc123",
     ) -> str:
-        return json.dumps({
-            "t": table, "op": op, "id": row_id,
-            "uid": user_id, "tab": tab,
-        })
+        return json.dumps(
+            {
+                "t": table,
+                "op": op,
+                "id": row_id,
+                "uid": user_id,
+                "tab": tab,
+            }
+        )
 
     def test_dispatch_to_correct_user(self) -> None:
         q = self.bus.subscribe(10)
@@ -66,7 +71,7 @@ class TestEventBusDispatch:
         # Fill the queue (maxsize=256)
         for i in range(256):
             self.bus._on_notify(  # type: ignore[arg-type]
-                None,
+                None,  # pyright: ignore[reportArgumentType]
                 0,
                 "events",
                 self._make_payload(user_id=10, row_id=i),
@@ -74,7 +79,7 @@ class TestEventBusDispatch:
         assert q.full()
         # This should not raise
         self.bus._on_notify(  # type: ignore[arg-type]
-            None,
+            None,  # pyright: ignore[reportArgumentType]
             0,
             "events",
             self._make_payload(user_id=10, row_id=999),


### PR DESCRIPTION
## Summary
- Split `batch_create_todos` (cyclomatic complexity 31, ~230 lines) into 7 private helper functions matching existing phase comments
- Main function reduced to ~30 lines of orchestration
- Pure refactor — no behavior changes

Helpers extracted: `_validate_batch_wiki_page`, `_validate_batch_depends_on`, `_detect_batch_duplicates`, `_prepare_batch_todos`, `_resolve_batch_parent_indices`, `_create_batch_dependencies`, `_link_batch_wiki_pages`

https://todo.brooksmcmillin.com/task/478

## Test plan
- [x] All 43 batch-related tests pass (`test_todos.py`, `test_task_dependencies.py`, `test_wiki.py -k batch`)
- [x] ruff check, ruff-format, pyright all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)