### PR TITLE
fix(oauth): register dynamic clients as public in backend

### DIFF
--- a/packages/taskmanager-sdk/taskmanager_sdk/client.py
+++ b/packages/taskmanager-sdk/taskmanager_sdk/client.py
@@ -1510,6 +1510,9 @@ class TaskManagerClient:
         Returns:
             ApiResponse with created OAuth client data
         """
+        is_public = (
+            token_endpoint_auth_method == "none" if token_endpoint_auth_method else None
+        )
         return self._make_request(
             "POST",
             "/oauth/clients/system",
@@ -1519,7 +1522,7 @@ class TaskManagerClient:
                 **self._build_params(
                     grantTypes=grant_types,
                     scopes=scopes,
-                    token_endpoint_auth_method=token_endpoint_auth_method,
+                    isPublic=is_public,
                 ),
             },
         )

--- a/services/mcp-auth/mcp_auth/auth_server.py
+++ b/services/mcp-auth/mcp_auth/auth_server.py
@@ -963,6 +963,7 @@ def create_authorization_server(
             redirect_uris=redirect_uris,
             grant_types=["authorization_code", "refresh_token", "device_code"],
             scopes=[auth_settings.mcp_scope],
+            token_endpoint_auth_method="none",
         )
 
         logger.info(f"API response status: {api_response.success}")

--- a/services/mcp-auth/tests/test_client_registration.py
+++ b/services/mcp-auth/tests/test_client_registration.py
@@ -46,10 +46,12 @@ def _create_client_info(
     """Create an OAuthClientInformationFull for testing."""
     return OAuthClientInformationFull(
         client_id=client_id,
-        redirect_uris=[AnyHttpUrl(u) for u in (redirect_uris or ["http://localhost:3000/callback"])],
+        redirect_uris=[
+            AnyHttpUrl(u) for u in (redirect_uris or ["http://localhost:3000/callback"])
+        ],
         grant_types=grant_types or ["authorization_code", "refresh_token"],
         scope=scope,
-        token_endpoint_auth_method=auth_method,
+        token_endpoint_auth_method=auth_method,  # type: ignore[arg-type]
     )
 
 
@@ -243,9 +245,7 @@ class TestRegisterWithTaskmanager:
         """Handles success=True but data=None without raising."""
         mock_api = MagicMock()
         mock_api.token_expires_at = 9999999999
-        mock_api.create_system_oauth_client.return_value = MagicMock(
-            success=True, data=None
-        )
+        mock_api.create_system_oauth_client.return_value = MagicMock(success=True, data=None)
         provider = _create_provider(api_client=mock_api)
         client_info = _create_client_info()
 


### PR DESCRIPTION
## Summary
- MCP auth server registration now passes `token_endpoint_auth_method="none"` when creating OAuth clients, and the SDK maps this to `isPublic=true` for the backend
- Fixes `invalid_client` error during OAuth device flow token polling, where the backend required a client_secret that was never forwarded
- Fixes pre-existing pyright error in mcp-auth test file

## Context
The MCP auth server was creating clients with `is_public=False` (backend default), then treating them as public locally via a name-based "claude-code" heuristic. This worked for authorization code flow (which forwards the stored client_secret in the proxy) but broke device flow (which doesn't forward the secret), causing `invalid_client` errors.

## Test plan
- [x] SDK tests pass (134)
- [x] MCP auth tests pass (110)
- [x] Backend OAuth tests pass (81)
- [ ] Deploy and test device flow end-to-end with remote-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)