### PR TITLE
chore(backend): fix dead code and cleanup items, add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,184 @@
+# Contributing to TaskManager
+
+Thank you for your interest in contributing to TaskManager. This document covers the development workflow, coding standards, and expectations for pull requests.
+
+## Table of Contents
+
+- [Pre-commit Setup](#pre-commit-setup)
+- [Branch Naming Conventions](#branch-naming-conventions)
+- [Test Requirements](#test-requirements)
+- [PR Checklist](#pr-checklist)
+
+---
+
+## Pre-commit Setup
+
+TaskManager uses [pre-commit](https://pre-commit.com/) to enforce consistent code quality across all languages in the monorepo.
+
+### Installation
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+This installs the git hooks that run automatically before each commit.
+
+### What the hooks check
+
+- **General**: trailing whitespace, YAML/JSON/TOML validation, secret detection
+- **Python**: ruff (lint + format), pyright (type checking), bandit (security scanning)
+- **Node.js**: eslint, prettier
+- **Docker**: hadolint
+
+### Running hooks manually
+
+```bash
+# Run on all files (useful before first commit or after hook updates)
+pre-commit run --all-files
+
+# Or via the Makefile shortcut
+make pre-commit
+```
+
+### Bypassing hooks (discouraged)
+
+Hooks should not be bypassed unless there is a specific, documented reason. If a hook is failing, investigate and fix the root cause. Do not use `--no-verify`.
+
+---
+
+## Branch Naming Conventions
+
+Branch names should follow this format:
+
+```
+<type>/<short-description>
+```
+
+### Types
+
+| Type | When to use |
+|------|-------------|
+| `feat/` | New features or capabilities |
+| `fix/` | Bug fixes |
+| `chore/` | Maintenance, refactoring, tooling updates |
+| `docs/` | Documentation-only changes |
+| `test/` | Test additions or improvements |
+| `ci/` | CI/CD configuration changes |
+
+### Examples
+
+```
+feat/add-wiki-search
+fix/session-expiry-bug
+chore/update-dependencies
+docs/api-reference
+test/auth-edge-cases
+ci/add-lint-step
+```
+
+Branch names should use lowercase letters, numbers, and hyphens only. Keep the description concise (3-5 words).
+
+---
+
+## Test Requirements
+
+**Unit tests are required for all new features and bug fixes.** Tests must be written before creating a PR or commit.
+
+### What to test
+
+- **Happy path**: the primary expected behavior
+- **Edge cases**: boundary conditions, empty inputs, large values
+- **Authorization**: verify that users cannot access or modify other users' data
+- **Error cases**: invalid input, missing resources, permission denied
+
+### Backend tests (FastAPI + pytest)
+
+Tests live in `services/backend/tests/`. Run them with:
+
+```bash
+cd services/backend
+uv run pytest tests/ -v
+```
+
+For a specific test file:
+
+```bash
+uv run pytest tests/test_todos.py -v
+```
+
+Stop at first failure:
+
+```bash
+uv run pytest tests/ -x -v
+```
+
+### Frontend tests (Playwright)
+
+Tests live in `services/frontend/tests/`. Run them with:
+
+```bash
+cd services/frontend
+npm test
+```
+
+### MCP service and SDK tests
+
+Each service has its own test suite:
+
+```bash
+cd services/mcp-auth && uv run pytest tests/ -v
+cd services/mcp-resource && uv run pytest tests/ -v
+cd packages/taskmanager-sdk && uv run pytest tests/ -v
+```
+
+### Running all tests from the root
+
+```bash
+make test
+```
+
+### Test must pass before PR
+
+CI runs all tests automatically. Do not open a PR with known test failures.
+
+---
+
+## PR Checklist
+
+Before opening a pull request, verify the following:
+
+### Code quality
+
+- [ ] All new functions and methods have type hints (Python)
+- [ ] Python uses built-in types (`list`, `dict`) not `typing.List`, `typing.Dict`
+- [ ] Python uses `X | None` instead of `Optional[X]`
+- [ ] No dead code or unused imports introduced
+- [ ] No secrets, credentials, or environment-specific values committed
+
+### Tests
+
+- [ ] New tests written for all new features and bug fixes
+- [ ] All existing tests pass locally (`make test` or per-service commands)
+- [ ] Tests cover the happy path, edge cases, and authorization checks
+
+### Linting and formatting
+
+- [ ] Ruff lint passes: `cd services/backend && uv run ruff check .`
+- [ ] Ruff format passes: `cd services/backend && uv run ruff format --check .`
+- [ ] Pyright type checking passes: `cd services/backend && uv run pyright`
+- [ ] Frontend lint passes: `cd services/frontend && npm run lint`
+- [ ] Pre-commit hooks pass: `pre-commit run --all-files`
+
+### PR description
+
+- [ ] PR title follows `<type>(<scope>): <short description>` format (e.g., `feat(wiki): add full-text search`)
+- [ ] Description explains **what** changed and **why**
+- [ ] Related task URL included if applicable (e.g., `Task: https://todo.brooksmcmillin.com/task/123`)
+- [ ] Breaking changes documented if any
+
+### Review
+
+- [ ] Self-reviewed the diff before marking ready for review
+- [ ] CI is green (all checks pass)
+- [ ] Addressed all review comments before requesting re-review

--- a/services/backend/app/api/auth.py
+++ b/services/backend/app/api/auth.py
@@ -1,10 +1,11 @@
 """Authentication API routes."""
 
+from typing import Annotated
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import AfterValidator, BaseModel, EmailStr, Field
 from sqlalchemy import delete, select
 
 from app.config import settings
@@ -26,23 +27,31 @@ router = APIRouter(prefix="/api/auth", tags=["auth"])
 account_update_rate_limiter = RateLimiter(max_attempts=5, window_ms=300000)
 
 
+def _check_password_strength(v: str) -> str:
+    """Validate that a password meets complexity requirements."""
+    if not validate_password_strength(v):
+        raise ValueError(
+            "Password must contain at least 2 of: "
+            "lowercase, uppercase, numbers, special chars"
+        )
+    return v
+
+
+# Reusable annotated type for passwords that enforces complexity requirements.
+StrongPassword = Annotated[
+    str,
+    Field(min_length=8),
+    AfterValidator(_check_password_strength),
+]
+
+
 # Request/Response schemas
 class RegisterRequest(BaseModel):
     """User registration request."""
 
     email: EmailStr
-    password: str = Field(..., min_length=8)
+    password: StrongPassword
     registration_code: str | None = Field(None, min_length=1)
-
-    @field_validator("password")
-    @classmethod
-    def password_strong(cls, v: str) -> str:
-        if not validate_password_strength(v):
-            raise ValueError(
-                "Password must contain at least 2 of: "
-                "lowercase, uppercase, numbers, special chars"
-            )
-        return v
 
 
 class LoginRequest(BaseModel):
@@ -77,17 +86,7 @@ class UpdatePasswordRequest(BaseModel):
     """Update password request."""
 
     current_password: str
-    new_password: str = Field(..., min_length=8)
-
-    @field_validator("new_password")
-    @classmethod
-    def password_strong(cls, v: str) -> str:
-        if not validate_password_strength(v):
-            raise ValueError(
-                "Password must contain at least 2 of: "
-                "lowercase, uppercase, numbers, special chars"
-            )
-        return v
+    new_password: StrongPassword
 
 
 @router.post("/register", status_code=201)

--- a/services/backend/app/api/todos.py
+++ b/services/backend/app/api/todos.py
@@ -273,6 +273,11 @@ class TodoResponse(BaseModel):
 
 
 # Helper functions
+def _to_float(value: object) -> float | None:
+    """Convert a value to float, returning None if value is None."""
+    return float(value) if value is not None else None  # type: ignore[arg-type]
+
+
 def _build_dependency_response(
     todo: Todo, project_name: str | None = None
 ) -> DependencyResponse:
@@ -313,12 +318,8 @@ def _build_subtask_response(subtask: Todo) -> SubtaskResponse:
         status=subtask.status,
         due_date=subtask.due_date,
         deadline_type=subtask.deadline_type,
-        estimated_hours=float(subtask.estimated_hours)
-        if subtask.estimated_hours is not None
-        else None,
-        actual_hours=float(subtask.actual_hours)
-        if subtask.actual_hours is not None
-        else None,
+        estimated_hours=_to_float(subtask.estimated_hours),
+        actual_hours=_to_float(subtask.actual_hours),
         position=subtask.position,
         created_at=subtask.created_at,
         updated_at=subtask.updated_at,
@@ -397,12 +398,8 @@ def _build_todo_response(
         tags=todo.tags or [],
         context=todo.context,
         time_horizon=todo.time_horizon,
-        estimated_hours=float(todo.estimated_hours)
-        if todo.estimated_hours is not None
-        else None,
-        actual_hours=float(todo.actual_hours)
-        if todo.actual_hours is not None
-        else None,
+        estimated_hours=_to_float(todo.estimated_hours),
+        actual_hours=_to_float(todo.actual_hours),
         position=todo.position,
         parent_id=todo.parent_id,
         parent_task=parent_task_response,

--- a/services/backend/app/api/wiki.py
+++ b/services/backend/app/api/wiki.py
@@ -200,7 +200,7 @@ def generate_slug(title: str) -> str:
     return slug or "untitled"
 
 
-def extract_snippet(content: str, query: str, max_len: int = 200) -> str | None:
+def extract_snippet(content: str, query: str) -> str | None:
     """Extract a snippet of content around the first match of query."""
     idx = content.lower().find(query.lower())
     if idx == -1:
@@ -1182,9 +1182,7 @@ async def _notify_subscribers(
             continue
         notified_users.add(sub.user_id)
 
-        is_delete = (
-            notification_type == NotificationType.WIKI_PAGE_DELETED
-        )
+        is_delete = notification_type == NotificationType.WIKI_PAGE_DELETED
         notification = Notification(
             user_id=sub.user_id,
             notification_type=notification_type,

--- a/services/backend/tests/test_relay.py
+++ b/services/backend/tests/test_relay.py
@@ -1,6 +1,7 @@
 """Tests for the MCP Relay admin proxy endpoints."""
 
 import json
+from collections.abc import Mapping
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -67,7 +68,7 @@ async def regular_client(client: AsyncClient, regular_user: User) -> AsyncClient
 
 
 def _make_response(
-    json_data: dict[str, object],
+    json_data: Mapping[str, object],
     status_code: int = 200,
     method: str = "GET",
 ) -> httpx.Response:
@@ -165,10 +166,16 @@ async def test_clear_non_admin_returns_403(regular_client: AsyncClient) -> None:
 async def test_list_channels(admin_client: AsyncClient) -> None:
     relay_data = {
         "channels": [
-            {"name": "test-ch", "message_count": 5, "last_activity": "2026-01-01T00:00:00Z"}
+            {
+                "name": "test-ch",
+                "message_count": 5,
+                "last_activity": "2026-01-01T00:00:00Z",
+            }
         ]
     }
-    mock_client = _mock_relay_client({"/debug/api/channels": _make_response(relay_data)})
+    mock_client = _mock_relay_client(
+        {"/debug/api/channels": _make_response(relay_data)}
+    )
 
     with patch("app.api.relay.httpx.AsyncClient") as mock_cls:
         mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -219,7 +226,11 @@ async def test_send_message(admin_client: AsyncClient) -> None:
         "timestamp": "2026-01-01T00:00:00Z",
     }
     mock_client = _mock_relay_client(
-        {"/debug/api/channels/test-ch/messages": _make_response(relay_data, status_code=201)}
+        {
+            "/debug/api/channels/test-ch/messages": _make_response(
+                relay_data, status_code=201
+            )
+        }
     )
 
     with patch("app.api.relay.httpx.AsyncClient") as mock_cls:
@@ -252,9 +263,7 @@ async def test_invalid_channel_name_returns_400(admin_client: AsyncClient) -> No
     # (will fail at relay level, but pass validation)
     with patch("app.api.relay.httpx.AsyncClient") as mock_cls:
         mock_client = AsyncMock()
-        mock_client.post = AsyncMock(
-            side_effect=httpx.ConnectError("not running")
-        )
+        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("not running"))
         mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
         mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
         response = await admin_client.post(
@@ -287,7 +296,9 @@ async def test_clear_channel(admin_client: AsyncClient) -> None:
 async def test_relay_unreachable_channels(admin_client: AsyncClient) -> None:
     with patch("app.api.relay.httpx.AsyncClient") as mock_cls:
         mock_client = AsyncMock()
-        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+        mock_client.get = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
         mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
         mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -319,7 +330,9 @@ async def test_relay_timeout_messages(admin_client: AsyncClient) -> None:
 async def test_relay_unreachable_send(admin_client: AsyncClient) -> None:
     with patch("app.api.relay.httpx.AsyncClient") as mock_cls:
         mock_client = AsyncMock()
-        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+        mock_client.post = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
         mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
         mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -337,7 +350,9 @@ async def test_relay_unreachable_send(admin_client: AsyncClient) -> None:
 async def test_relay_unreachable_clear(admin_client: AsyncClient) -> None:
     with patch("app.api.relay.httpx.AsyncClient") as mock_cls:
         mock_client = AsyncMock()
-        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+        mock_client.post = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
         mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
         mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 


### PR DESCRIPTION
## Summary
- Fix dead `max_len` parameter in wiki.py `extract_snippet`
- Extract duplicated `password_strong` validator into `StrongPassword` Annotated type
- Fix `float()` conversion duplication for `estimated_hours`/`actual_hours` in response builders
- Fix pre-existing pyright type errors in `test_relay.py` (dict invariance - use `Mapping`)
- Create `CONTRIBUTING.md` covering pre-commit setup, branch naming, test requirements, PR checklist

Task: https://todo.brooksmcmillin.com/task/492

## Test plan
- [ ] All existing backend tests pass
- [ ] Ruff lint clean
- [ ] Pyright type checking passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)