### PR TITLE
infra: pin uv Dockerfile base images to versioned tag (0.6.6)

### DIFF
--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.12-slim AS builder
 
 WORKDIR /app
 
-# Install uv for dependency management
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+# Pinned uv version — update intentionally when upgrading uv
+COPY --from=ghcr.io/astral-sh/uv:0.6.6 /uv /bin/uv
 
 # Copy dependency files
 COPY pyproject.toml uv.lock README.md ./

--- a/services/mcp-auth/Dockerfile
+++ b/services/mcp-auth/Dockerfile
@@ -7,14 +7,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Set working directory
 WORKDIR /app
 
-# Install uv and git
-RUN apt-get update && apt-get install -y --no-install-recommends git curl \
-    && curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && apt-get purge -y curl && apt-get autoremove -y \
+# Install git (needed for uv sync with git-sourced dependencies)
+RUN apt-get update && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 
-# Add uv to PATH
-ENV PATH="/root/.local/bin:$PATH"
+# Pinned uv version — update intentionally when upgrading uv
+COPY --from=ghcr.io/astral-sh/uv:0.6.6 /uv /usr/local/bin/uv
 
 # Copy SDK and framework packages first (needed for local dependencies)
 COPY packages/taskmanager-sdk /packages/taskmanager-sdk
@@ -31,9 +29,8 @@ RUN sed -i 's|path = "../../packages/taskmanager-sdk"|path = "/packages/taskmana
 # Copy application code
 COPY services/mcp-auth/mcp_auth ./mcp_auth
 
-# Move uv to system path and create non-root user
-RUN cp /root/.local/bin/uv /usr/local/bin/uv && \
-    adduser --disabled-password --gecos "" appuser
+# Create non-root user
+RUN adduser --disabled-password --gecos "" appuser
 USER appuser
 
 # Expose port

--- a/services/mcp-relay/Dockerfile
+++ b/services/mcp-relay/Dockerfile
@@ -7,14 +7,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Set working directory
 WORKDIR /app
 
-# Install uv and git
-RUN apt-get update && apt-get install -y --no-install-recommends git curl \
-    && curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && apt-get purge -y curl && apt-get autoremove -y \
+# Install git (needed for uv sync with git-sourced dependencies)
+RUN apt-get update && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 
-# Add uv to PATH
-ENV PATH="/root/.local/bin:$PATH"
+# Pinned uv version — update intentionally when upgrading uv
+COPY --from=ghcr.io/astral-sh/uv:0.6.6 /uv /usr/local/bin/uv
 
 # Copy framework package (needed for local dependency)
 COPY packages/mcp-resource-framework /packages/mcp-resource-framework
@@ -29,9 +27,8 @@ RUN sed -i 's|path = "../../packages/mcp-resource-framework"|path = "/packages/m
 # Copy application code
 COPY services/mcp-relay/mcp_relay ./mcp_relay
 
-# Move uv to system path and create non-root user
-RUN cp /root/.local/bin/uv /usr/local/bin/uv && \
-    adduser --disabled-password --gecos "" appuser && \
+# Create non-root user
+RUN adduser --disabled-password --gecos "" appuser && \
     chown -R appuser:appuser /app
 USER appuser
 

--- a/services/mcp-resource/Dockerfile
+++ b/services/mcp-resource/Dockerfile
@@ -7,14 +7,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Set working directory
 WORKDIR /app
 
-# Install uv and git
-RUN apt-get update && apt-get install -y --no-install-recommends git curl \
-    && curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && apt-get purge -y curl && apt-get autoremove -y \
+# Install git (needed for uv sync with git-sourced dependencies)
+RUN apt-get update && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 
-# Add uv to PATH
-ENV PATH="/root/.local/bin:$PATH"
+# Pinned uv version — update intentionally when upgrading uv
+COPY --from=ghcr.io/astral-sh/uv:0.6.6 /uv /usr/local/bin/uv
 
 # Copy SDK and framework packages first (needed for local dependencies)
 COPY packages/taskmanager-sdk /packages/taskmanager-sdk
@@ -33,9 +31,8 @@ RUN sed -i 's|path = "../../packages/taskmanager-sdk"|path = "/packages/taskmana
 # Copy application code
 COPY services/mcp-resource/mcp_resource ./mcp_resource
 
-# Move uv to system path and create non-root user
-RUN cp /root/.local/bin/uv /usr/local/bin/uv && \
-    adduser --disabled-password --gecos "" appuser
+# Create non-root user
+RUN adduser --disabled-password --gecos "" appuser
 USER appuser
 
 # Expose port


### PR DESCRIPTION
## Summary

All Python service Dockerfiles had floating uv references that change silently on new uv releases:

- `backend`: used `COPY --from=ghcr.io/astral-sh/uv:latest` (floating `:latest` tag)
- `mcp-auth`, `mcp-relay`, `mcp-resource`: installed uv via `curl -LsSf https://astral.sh/uv/install.sh | sh` (no version pin)

This PR pins all of them to `0.6.6` for reproducible builds.

## Changes

- **backend**: Pinned `COPY --from=ghcr.io/astral-sh/uv:latest` → `COPY --from=ghcr.io/astral-sh/uv:0.6.6`
- **mcp-auth / mcp-relay / mcp-resource**: Replaced unpinned curl installer with `COPY --from=ghcr.io/astral-sh/uv:0.6.6 /uv /usr/local/bin/uv` — simpler, eliminates curl as a build dependency, and is clearly pinned
- Added `# Pinned uv version — update intentionally when upgrading uv` comment above each uv reference

## Task

Closes https://nexus.brooksmcmillin.com/task/849

## Testing

- No functional change; build behavior is identical unless uv releases a new version
- Docker build should succeed on all services